### PR TITLE
[MPT-11789] Change project script name to resolve conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 ]
 
 [project.scripts]
-swoext = "mpt_extension_sdk.runtime.swoext:main"
+swosdk = "mpt_extension_sdk.runtime.swoext:main"
 
 [project.entry-points."swo.mpt.sdk"]
 app_config = "mpt_extension_sdk.runtime.djapp.apps:ExtensionConfig"


### PR DESCRIPTION
project.script conflict between aws and sdk causing aws django commands to not be recognized sometimes.

solution:

partial extraction: sdk project script is swosdk, extension is swoext.

full extraction: revert sdk project script to swoext, removed from extension.

https://softwareone.atlassian.net/browse/MPT-11789