### PR TITLE
[BACKPORT] [MPT-11789] Change project script name to resolve conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ types-openpyxl = "3.1.*"
 types-requests = "2.31.*"
 
 [tool.poetry.scripts]
-swoext = 'mpt_extension_sdk.runtime.swoext:main'
+swosdk = 'mpt_extension_sdk.runtime.swoext:main'
 
 
 [tool.poetry.plugins."swo.mpt.sdk"]


### PR DESCRIPTION
project.script conflict between aws and sdk causing aws django commands to not be recognized sometimes.

solution:

partial extraction: sdk project script is swosdk, extension is swoext.

full extraction: revert sdk project script to swoext, removed from extension.

https://softwareone.atlassian.net/browse/MPT-11789