### PR TITLE
[MPT-12129] Implemented custom extension initializer capability in SDK

### DIFF
--- a/mpt_extension_sdk/constants.py
+++ b/mpt_extension_sdk/constants.py
@@ -5,3 +5,7 @@ CONSUME_EVENTS_HELP_TEXT = "Consume events from the MPT platform"
 DEFAULT_APP_CONFIG_GROUP = "swo.mpt.ext"
 DEFAULT_APP_CONFIG_NAME = "app_config"
 DJANGO_SETTINGS_MODULE = "mpt_extension_sdk.runtime.djapp.conf.default"
+ERR_DJANGO_SETTINGS_MODULE_TEXT = (
+    "DJANGO_SETTINGS_MODULE environment variable is not set. "
+    "Please set it to your Django settings module before running this command."
+)

--- a/mpt_extension_sdk/runtime/commands/django.py
+++ b/mpt_extension_sdk/runtime/commands/django.py
@@ -9,7 +9,7 @@ from mpt_extension_sdk.constants import (
     DEFAULT_APP_CONFIG_NAME,
     DJANGO_SETTINGS_MODULE,
 )
-from mpt_extension_sdk.runtime.initializer import initialize
+from mpt_extension_sdk.runtime.utils import initialize_extension
 
 
 @click.command(
@@ -20,20 +20,21 @@ from mpt_extension_sdk.runtime.initializer import initialize
 @click.pass_context
 def django(ctx, management_args):  # pragma: no cover
     "Execute Django subcommands."
+
     from django.conf import settings
 
-    initialize(
-        {
-            "group": DEFAULT_APP_CONFIG_GROUP,
-            "name": DEFAULT_APP_CONFIG_NAME,
-            "django_settings_module": DJANGO_SETTINGS_MODULE,
-        }
-    )
+    options = {
+        "group": DEFAULT_APP_CONFIG_GROUP,
+        "name": DEFAULT_APP_CONFIG_NAME,
+        "django_settings_module": DJANGO_SETTINGS_MODULE,
+    }
+
+    initialize_extension(options=options)
 
     if settings.USE_APPLICATIONINSIGHTS:
         tracer = trace.get_tracer(__name__)
         tracer_context = tracer.start_as_current_span(
-            f"Running Django command {management_args}",
+            f"Running Django command {management_args[0]}",
         )
     else:
         tracer_context = nullcontext()

--- a/mpt_extension_sdk/runtime/commands/run.py
+++ b/mpt_extension_sdk/runtime/commands/run.py
@@ -30,13 +30,15 @@ def run(component, color, debug, reload, debug_py):
         host, port = debug_py.split(":")
         debugpy.listen((host, int(port)))  # noqa
 
+    options = {
+        "color": color,
+        "debug": debug,
+        "reload": reload,
+        "component": component,
+    }
+
     master = Master(
-        {
-            "color": color,
-            "debug": debug,
-            "reload": reload,
-            "component": component,
-        },
+        options,
         settings=settings,
     )
     master.run()  # pragma: no cover

--- a/mpt_extension_sdk/runtime/master.py
+++ b/mpt_extension_sdk/runtime/master.py
@@ -53,9 +53,7 @@ class Master:
                     "gunicorn": start_gunicorn,
                 }
             case "consumer":
-                self.proc_targets = {
-                    "event-consumer": start_event_consumer,
-                }
+                self.proc_targets = {"event-consumer": start_event_consumer}
             case _:
                 self.proc_targets = {
                     "event-consumer": start_event_consumer,

--- a/mpt_extension_sdk/runtime/workers.py
+++ b/mpt_extension_sdk/runtime/workers.py
@@ -6,7 +6,7 @@ from mpt_extension_sdk.constants import (
     DEFAULT_APP_CONFIG_GROUP,
     DEFAULT_APP_CONFIG_NAME,
 )
-from mpt_extension_sdk.runtime.initializer import initialize
+from mpt_extension_sdk.runtime.utils import initialize_extension
 
 
 class ExtensionWebApplication(BaseApplication):
@@ -29,14 +29,16 @@ class ExtensionWebApplication(BaseApplication):
 
 
 def start_event_consumer(options):
-    initialize(options)
+    initialize_extension(options)
     call_command("consume_events")
 
 
 def start_gunicorn(
-    options, group=DEFAULT_APP_CONFIG_GROUP, name=DEFAULT_APP_CONFIG_NAME
+    options,
+    group=DEFAULT_APP_CONFIG_GROUP,
+    name=DEFAULT_APP_CONFIG_NAME,
 ):
-    initialize(options, group=group, name=name)
+    initialize_extension(options, group=group, name=name)
 
     logging_config = {
         "version": 1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -867,3 +867,13 @@ def mock_product_ids_for_expression():
 @pytest.fixture
 def mock_product_id_for_expression():
     return "PRD-1"
+
+
+@pytest.fixture
+def mock_process_id():
+    return "12345"
+
+
+@pytest.fixture
+def mock_gunicorn_options():
+    return {"component": "api", "debug": False}

--- a/tests/django/settings.py
+++ b/tests/django/settings.py
@@ -180,3 +180,7 @@ EXTENSION_CONFIG = {
     "MAX_RETRY_ATTEMPS": "10",
     "DUE_DATE_DAYS": "30",
 }
+
+INITIALIZER = os.getenv(
+    "MPT_INITIALIZER", "mpt_extension_sdk.runtime.initializer.initialize"
+)

--- a/tests/runtime/initializer.py
+++ b/tests/runtime/initializer.py
@@ -1,0 +1,11 @@
+"""
+Test initializer module for testing purposes.
+"""
+
+
+def initialize_test(options, group=None, name=None):
+    """
+    Test initialization function for unit tests.
+    Needs to exist for tests to run properly.
+    """
+    pass

--- a/tests/runtime/test_runtime_app.py
+++ b/tests/runtime/test_runtime_app.py
@@ -8,7 +8,15 @@ from mpt_extension_sdk.runtime.master import Master
 def test_run(mocker):
     component = "all"
 
+    def mock_initializer(*args, **kwargs):
+        pass
+
     mock_master_run = mocker.patch.object(Master, "run", return_value=None)
+
+    mocker.patch(
+        "mpt_extension_sdk.runtime.utils.get_initializer_function",
+        return_value=mock_initializer,
+    )
 
     runner = CliRunner()
     result = runner.invoke(run, [component, "--color"])
@@ -21,7 +29,15 @@ def test_run_with_debug_py(mocker):
 
     debug_py = "localhost:5678"
 
+    def mock_initializer(*args, **kwargs):
+        pass
+
     mock_master_run = mocker.patch.object(Master, "run", return_value=None)
+
+    mocker.patch(
+        "mpt_extension_sdk.runtime.utils.get_initializer_function",
+        return_value=mock_initializer,
+    )
 
     mock_debugpy = mocker.patch(
         "mpt_extension_sdk.runtime.commands.run.debugpy.listen", return_value=None

--- a/tests/runtime/test_runtime_master.py
+++ b/tests/runtime/test_runtime_master.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 from django.test import override_settings
 
 from mpt_extension_sdk.runtime.master import Master
@@ -7,7 +9,19 @@ from mpt_extension_sdk.runtime.master import Master
     MPT_PRODUCTS_IDS="PRD-1111-1111",
     LOGGING={"loggers": {"mpt_extension_sdk": {}, "swo.mpt": {}}},
 )
-def test_master_start_signals_handler_all(runtime_master_options_factory, settings):
+def test_master_start_signals_handler_all(
+    mocker, runtime_master_options_factory, settings, mock_process_id
+):
+    """
+    Test master start with signals handler for all components
+    """
+
+    mock_start_process = mocker.patch("mpt_extension_sdk.runtime.master.start_process")
+
+    mock_process = MagicMock(autospec=True)
+    mock_process.pid = mock_process_id
+    mock_start_process.return_value = mock_process
+
     mock_runtime_master_options = runtime_master_options_factory(component="all")
     mock_runtime_master = Master(mock_runtime_master_options, settings=settings)
     mock_runtime_master.setup_signals_handler()
@@ -21,7 +35,19 @@ def test_master_start_signals_handler_all(runtime_master_options_factory, settin
     MPT_PRODUCTS_IDS="PRD-1111-1111",
     LOGGING={"loggers": {"mpt_extension_sdk": {}, "swo.mpt": {}}},
 )
-def test_master_start_signals_handler_api(runtime_master_options_factory, settings):
+def test_master_start_signals_handler_api(
+    mocker, runtime_master_options_factory, settings, mock_process_id
+):
+    """
+    Test master start with signals handler for API component
+    """
+
+    mock_start_process = mocker.patch("mpt_extension_sdk.runtime.master.start_process")
+
+    mock_process = MagicMock(autospec=True)
+    mock_process.pid = mock_process_id
+    mock_start_process.return_value = mock_process
+
     mock_runtime_master_options = runtime_master_options_factory(component="api")
     mock_runtime_master = Master(mock_runtime_master_options, settings=settings)
     mock_runtime_master.setup_signals_handler()
@@ -36,8 +62,17 @@ def test_master_start_signals_handler_api(runtime_master_options_factory, settin
     LOGGING={"loggers": {"mpt_extension_sdk": {}, "swo.mpt": {}}},
 )
 def test_master_start_signals_handler_consumer(
-    runtime_master_options_factory, settings
+    mocker, runtime_master_options_factory, settings, mock_process_id
 ):
+    """
+    Test master start with signals handler for consumer component
+    """
+    mock_start_process = mocker.patch("mpt_extension_sdk.runtime.master.start_process")
+
+    mock_process = MagicMock(autospec=True)
+    mock_process.pid = mock_process_id
+    mock_start_process.return_value = mock_process
+
     mock_runtime_master_options = runtime_master_options_factory(component="consumer")
     mock_runtime_master = Master(mock_runtime_master_options, settings=settings)
     mock_runtime_master.setup_signals_handler()
@@ -51,7 +86,18 @@ def test_master_start_signals_handler_consumer(
     MPT_PRODUCTS_IDS="PRD-1111-1111",
     LOGGING={"loggers": {"mpt_extension_sdk": {}, "swo.mpt": {}}},
 )
-def test_master_start_signals_handler_other(runtime_master_options_factory, settings):
+def test_master_start_signals_handler_other(
+    mocker, runtime_master_options_factory, settings, mock_process_id
+):
+    """
+    Test master start with signals handler for other components
+    """
+    mock_start_process = mocker.patch("mpt_extension_sdk.runtime.master.start_process")
+
+    mock_process = MagicMock(autospec=True)
+    mock_process.pid = mock_process_id
+    mock_start_process.return_value = mock_process
+
     mock_runtime_master_options = runtime_master_options_factory(component="other")
     mock_runtime_master = Master(mock_runtime_master_options, settings=settings)
     mock_runtime_master.setup_signals_handler()
@@ -65,7 +111,18 @@ def test_master_start_signals_handler_other(runtime_master_options_factory, sett
     MPT_PRODUCTS_IDS="PRD-1111-1111",
     LOGGING={"loggers": {"mpt_extension_sdk": {}, "swo.mpt": {}}},
 )
-def test_master_restart_signals_handler(runtime_master_options_factory, settings):
+def test_master_restart_signals_handler(
+    mocker, runtime_master_options_factory, settings, mock_process_id
+):
+    """
+    Test master restart with signals handler
+    """
+    mock_start_process = mocker.patch("mpt_extension_sdk.runtime.master.start_process")
+
+    mock_process = MagicMock(autospec=True)
+    mock_process.pid = mock_process_id
+    mock_start_process.return_value = mock_process
+
     mock_runtime_master_options = runtime_master_options_factory(component="all")
     mock_runtime_master = Master(mock_runtime_master_options, settings=settings)
     mock_runtime_master.setup_signals_handler()
@@ -80,7 +137,18 @@ def test_master_restart_signals_handler(runtime_master_options_factory, settings
     MPT_PRODUCTS_IDS="PRD-1111-1111",
     LOGGING={"loggers": {"mpt_extension_sdk": {}, "swo.mpt": {}}},
 )
-def test_master_stop_signals_handler(runtime_master_options_factory, settings):
+def test_master_stop_signals_handler(
+    mocker, runtime_master_options_factory, settings, mock_process_id
+):
+    """
+    Test master stop with signals handler
+    """
+    mock_start_process = mocker.patch("mpt_extension_sdk.runtime.master.start_process")
+
+    mock_process = MagicMock(autospec=True)
+    mock_process.pid = mock_process_id
+    mock_start_process.return_value = mock_process
+
     mock_runtime_master_options = runtime_master_options_factory(component="all")
     mock_runtime_master = Master(mock_runtime_master_options, settings=settings)
     mock_runtime_master.setup_signals_handler()

--- a/tests/runtime/test_runtime_utils.py
+++ b/tests/runtime/test_runtime_utils.py
@@ -10,22 +10,32 @@ from mpt_extension_sdk.runtime.utils import (
     get_extension_app_config,
     get_extension_app_config_name,
     get_extension_variables,
+    get_initializer_function,
     get_urlpatterns,
 )
 
 
 def test_get_extension_app_config_name(mock_app_group_name):
+    """
+    Test that the app config name is correctly constructed from the app group name.
+    """
     app_config_name = get_extension_app_config_name(group=mock_app_group_name)
     assert app_config_name == "mpt_extension_sdk.runtime.djapp.apps.ExtensionConfig"
 
 
 def test_get_extension_appconfig(mock_app_group_name):
+    """
+    Test that the app config is correctly retrieved from the app group name.
+    """
     appconfig = get_extension_app_config(group=mock_app_group_name)
     assert appconfig.name == "mpt_extension_sdk"
     assert appconfig.label == "mpt_extension_sdk"
 
 
 def test_get_extension(mock_app_group_name):
+    """
+    Test that the extension is correctly retrieved from the app group name.
+    """
     extension = get_extension(group=mock_app_group_name)
     assert extension is not None
     assert isinstance(extension.api, NinjaAPI)
@@ -33,6 +43,9 @@ def test_get_extension(mock_app_group_name):
 
 
 def test_get_events_registry(mock_app_group_name):
+    """
+    Test that the events registry is correctly retrieved from the extension.
+    """
     events_registry = get_events_registry(group=mock_app_group_name)
     assert events_registry.listeners is not None
     assert isinstance(events_registry.listeners, dict)
@@ -44,6 +57,9 @@ def test_get_extension_variables_valid(
     mock_ext_expected_environment_values,
     mock_json_ext_variables,
 ):
+    """
+    Test that the extension variables are correctly retrieved from the environment
+    """
     for key, value in mock_valid_env_values.items():
         monkeypatch.setenv(key, value)
 
@@ -55,6 +71,9 @@ def test_get_extension_variables_valid(
 def test_get_extension_variables_json_error(
     monkeypatch, mock_invalid_env_values, mock_json_ext_variables
 ):
+    """
+    Test that an error is raised when the JSON environment variables are not well formatted.
+    """
     for key, value in mock_invalid_env_values.items():
         monkeypatch.setenv(key, value)
 
@@ -65,6 +84,9 @@ def test_get_extension_variables_json_error(
 
 
 def test_setup_contexts(mpt_client, order_factory):
+    """
+    Test setup_contexts function with a single order.
+    """
     orders = [order_factory()]
     contexts = setup_contexts(mpt_client, orders)
     assert len(contexts) == 1
@@ -72,6 +94,9 @@ def test_setup_contexts(mpt_client, order_factory):
 
 
 def test_get_api_urls_no_extension():
+    """
+    Test get_api_url when no extension is provided.
+    """
     extension = None
     urlpatterns = get_urlpatterns(extension)
     assert len(urlpatterns) == 1
@@ -81,6 +106,9 @@ def test_get_api_url_with_no_api_url(
     mocker,
     mock_app_group_name,
 ):
+    """
+    Test get_api_url when no API URL is set in the extension.
+    """
     extension = get_extension(group=mock_app_group_name)
     mocker.patch(
         "mpt_extension_sdk.runtime.utils.get_api_url",
@@ -91,6 +119,48 @@ def test_get_api_url_with_no_api_url(
 
 
 def test_get_api_url_no_extension():
+    """
+    Test that get_api_url returns None when no extension is provided.
+    """
     extension = None
     api_url = get_api_url(extension)
     assert api_url is None
+
+
+def test_get_initializer_function(monkeypatch):
+    """
+    Test that the initializer function is correctly retrieved.
+    """
+    monkeypatch.setenv("MPT_INITIALIZER", "tests.runtime.initializer.initialize_test")
+
+    func = get_initializer_function()
+    assert func is not None
+    assert isinstance(func, str)
+    assert func == "tests.runtime.initializer.initialize_test"
+
+
+def test_initialize_extension_calls_initializer(mocker):
+    """
+    Test that initialize_extension imports and
+    calls the initializer function with the correct arguments.
+    """
+    from mpt_extension_sdk.runtime import utils
+
+    mock_initializer = mocker.Mock(autospec=True)
+
+    mock_import_string = mocker.patch(
+        "mpt_extension_sdk.runtime.utils.import_string", return_value=mock_initializer
+    )
+
+    mocker.patch(
+        "mpt_extension_sdk.runtime.utils.get_initializer_function",
+        return_value="dummy.path.to.initializer",
+    )
+
+    options = {"test_name": "test_value"}
+    group = "test_group"
+    name = "test_name"
+
+    utils.initialize_extension(options, group=group, name=name)
+    mock_import_string.assert_called_once_with("dummy.path.to.initializer")
+    mock_initializer.assert_called_once_with(options, group=group, name=name)

--- a/tests/runtime/test_tracer.py
+++ b/tests/runtime/test_tracer.py
@@ -1,4 +1,3 @@
-
 import importlib
 from unittest.mock import MagicMock
 
@@ -13,10 +12,11 @@ def test_dynamic_trace_span(mocker):
     mocker.patch(
         "mpt_extension_sdk.runtime.tracer.trace.get_tracer",
         autospec=True,
-        return_value=mocker_tracer_instance
+        return_value=mocker_tracer_instance,
     )
 
     import mpt_extension_sdk.runtime.tracer as tracer
+
     importlib.reload(tracer)
 
     def name_fn(x):


### PR DESCRIPTION
Implement custom extension initializer capability in SDK. Default is one in SDK. Extension should be able to override this.

NOTE: Optimization for mpt_client will be implemented after task because adobe will also have to be updated and it would be better to update sdk, aws, and adobe as a separate task instead of making this current task larger in scope.
 
https://softwareone.atlassian.net/browse/MPT-12129