### PR TITLE
MPT-12622: add mpt assets support

### DIFF
--- a/mpt_extension_sdk/mpt_http/mpt.py
+++ b/mpt_extension_sdk/mpt_http/mpt.py
@@ -125,6 +125,42 @@ def update_asset(mpt_client, order_id, asset_id, **kwargs):
 
 
 @wrap_mpt_http_error
+def create_agreement_asset(mpt_client, asset):
+    """Create a new agreement asset."""
+    response = mpt_client.post("/commerce/assets", json=asset)
+    response.raise_for_status()
+    return response.json()
+
+
+@wrap_mpt_http_error
+def get_agreement_asset_by_external_id(mpt_client, agreement_id, asset_external_id):
+    """Retrieve an agreement asset by external ID."""
+    response = mpt_client.get(
+        f"/commerce/assets?eq(externalIds.vendor,{asset_external_id})"
+        f"&eq(agreement.id,{agreement_id})"
+        f"&eq(status,Active)"
+        f"&select=agreement.id&limit=1"
+    )
+    response.raise_for_status()
+    assets = response.json()
+    return assets["data"][0] if assets["data"] else None
+
+
+@wrap_mpt_http_error
+def get_order_asset_by_external_id(mpt_client, order_id, asset_external_id):
+    """Retrieve an order asset by its external ID."""
+    response = mpt_client.get(
+        f"/commerce/orders/{order_id}/assets?eq(externalIds.vendor,{asset_external_id})&limit=1",
+    )
+    response.raise_for_status()
+    assets = response.json()
+    if assets["$meta"]["pagination"]["total"] == 1:
+        return assets["data"][0]
+
+    return None
+
+
+@wrap_mpt_http_error
 def create_subscription(mpt_client, order_id, subscription):
     """Create a new subscription for an order."""
     response = mpt_client.post(


### PR DESCRIPTION
Add support to:

* Create a new agreement asset
* Retrieve an agreement asset by externalId
* Retrieve an order asset by externalId


These endpoints will be used to implement asset creation for deployment agreements