### PR TITLE
MPT-12388: rename assets methods

### DIFF
--- a/mpt_extension_sdk/mpt_http/mpt.py
+++ b/mpt_extension_sdk/mpt_http/mpt.py
@@ -109,7 +109,15 @@ def set_processing_template(mpt_client, order_id, template):
 
 
 @wrap_mpt_http_error
-def create_asset(mpt_client, order_id, asset):
+def create_asset(mpt_client, asset):
+    """Create a new asset."""
+    response = mpt_client.post("/commerce/assets", json=asset)
+    response.raise_for_status()
+    return response.json()
+
+
+@wrap_mpt_http_error
+def create_order_asset(mpt_client, order_id, asset):
     """Create a new asset for an order."""
     response = mpt_client.post(f"/commerce/orders/{order_id}/assets", json=asset)
     response.raise_for_status()
@@ -117,17 +125,9 @@ def create_asset(mpt_client, order_id, asset):
 
 
 @wrap_mpt_http_error
-def update_asset(mpt_client, order_id, asset_id, **kwargs):
+def update_order_asset(mpt_client, order_id, asset_id, **kwargs):
     """Update an order asset."""
     response = mpt_client.put(f"/commerce/orders/{order_id}/assets/{asset_id}", json=kwargs)
-    response.raise_for_status()
-    return response.json()
-
-
-@wrap_mpt_http_error
-def create_agreement_asset(mpt_client, asset):
-    """Create a new agreement asset."""
-    response = mpt_client.post("/commerce/assets", json=asset)
     response.raise_for_status()
     return response.json()
 

--- a/tests/mpt_http/test_mpt.py
+++ b/tests/mpt_http/test_mpt.py
@@ -6,10 +6,10 @@ from responses import matchers
 from mpt_extension_sdk.mpt_http.mpt import (
     complete_order,
     create_agreement,
-    create_agreement_asset,
     create_agreement_subscription,
     create_asset,
     create_listing,
+    create_order_asset,
     create_subscription,
     fail_order,
     get_agreement,
@@ -43,8 +43,8 @@ from mpt_extension_sdk.mpt_http.mpt import (
     terminate_subscription,
     update_agreement,
     update_agreement_subscription,
-    update_asset,
     update_order,
+    update_order_asset,
     update_subscription,
 )
 from mpt_extension_sdk.mpt_http.wrap_http_error import MPTAPIError
@@ -224,7 +224,7 @@ def test_update_order_error(mpt_client, requests_mocker, mpt_error_factory):
     assert cv.value.payload["status"] == 404
 
 
-def test_create_asset(mpt_client, requests_mocker, assets_factory):
+def test_create_order_asset(mpt_client, requests_mocker, assets_factory):
     asset = assets_factory()[0]
     requests_mocker.post(
         urljoin(mpt_client.base_url, "commerce/orders/ORD-0000/assets"),
@@ -235,11 +235,12 @@ def test_create_asset(mpt_client, requests_mocker, assets_factory):
         ],
     )
 
-    created_asset = create_asset(mpt_client, "ORD-0000", asset)
+    created_asset = create_order_asset(mpt_client, "ORD-0000", asset)
+
     assert created_asset == asset
 
 
-def test_create_asset_error(mpt_client, requests_mocker, mpt_error_factory):
+def test_create_order_asset_error(mpt_client, requests_mocker, mpt_error_factory):
     requests_mocker.post(
         urljoin(mpt_client.base_url, "commerce/orders/ORD-0000/assets"),
         status=404,
@@ -247,12 +248,12 @@ def test_create_asset_error(mpt_client, requests_mocker, mpt_error_factory):
     )
 
     with pytest.raises(MPTAPIError) as cv:
-        create_asset(mpt_client, "ORD-0000", {})
+        create_order_asset(mpt_client, "ORD-0000", {})
 
     assert cv.value.payload["status"] == 404
 
 
-def test_update_asset(mpt_client, requests_mocker, assets_factory):
+def test_update_order_asset(mpt_client, requests_mocker, assets_factory):
     asset = assets_factory()
     requests_mocker.put(
         urljoin(
@@ -278,7 +279,7 @@ def test_update_asset(mpt_client, requests_mocker, assets_factory):
         ],
     )
 
-    updated_asset = update_asset(
+    updated_asset = update_order_asset(
         mpt_client,
         "ORD-0000",
         "AST-1234",
@@ -296,7 +297,7 @@ def test_update_asset(mpt_client, requests_mocker, assets_factory):
     assert updated_asset == asset
 
 
-def test_update_asset_error(mpt_client, requests_mocker, mpt_error_factory):
+def test_update_order_asset_error(mpt_client, requests_mocker, mpt_error_factory):
     requests_mocker.put(
         urljoin(mpt_client.base_url, "commerce/orders/ORD-0000/assets/AST-1234"),
         status=404,
@@ -304,12 +305,12 @@ def test_update_asset_error(mpt_client, requests_mocker, mpt_error_factory):
     )
 
     with pytest.raises(MPTAPIError) as cv:
-        update_asset(mpt_client, "ORD-0000", "AST-1234", parameters={})
+        update_order_asset(mpt_client, "ORD-0000", "AST-1234", parameters={})
 
     assert cv.value.payload["status"] == 404
 
 
-def test_create_agreement_asset(mpt_client, requests_mocker, assets_factory):
+def test_create_asset(mpt_client, requests_mocker, assets_factory):
     asset = assets_factory()
     requests_mocker.post(
         urljoin(mpt_client.base_url, "commerce/assets"),
@@ -318,7 +319,7 @@ def test_create_agreement_asset(mpt_client, requests_mocker, assets_factory):
         match=[matchers.json_params_matcher(asset)],
     )
 
-    created_asset = create_agreement_asset(mpt_client, asset)
+    created_asset = create_asset(mpt_client, asset)
 
     assert created_asset == asset
 


### PR DESCRIPTION
Rename the assets methods for create/update to be consistent with the endpoints name:

- orders: xxx_asset -> xxx_order_asset
- agreement: xxx_agreement_asset ->  xxx_asset