### PR TITLE
MPT-20495: fix meta version

### DIFF
--- a/compose.demo.yaml
+++ b/compose.demo.yaml
@@ -5,8 +5,6 @@ services:
       jaeger:
         condition: service_started
     env_file:
-#      - path: .env
-#        required: false
       - path: .env.demo
         required: true
     ports:

--- a/mock_app/settings.py
+++ b/mock_app/settings.py
@@ -1,13 +1,23 @@
-from typing import Self, override
+from dataclasses import dataclass
+from typing import Any, Self, override
 
 from mpt_extension_sdk.settings.extension import BaseExtensionSettings
 
 
+@dataclass(frozen=True)
 class ExtensionSettings(BaseExtensionSettings):
     """Extension settings."""
+
+    product_ids: tuple[str, ...]
+
+    @override
+    @property
+    def required_env_vars(self) -> list[tuple[Any, ...]]:
+        return [
+            (self.product_ids, "Product ids is required (MPT_PRODUCTS_IDS)"),
+        ]
 
     @override
     @classmethod
     def load(cls) -> Self:
-        """Load settings."""
-        return cls()
+        return cls(product_ids=tuple(cls.list_env("MPT_PRODUCTS_IDS")))

--- a/mpt_extension_sdk/extension_app.py
+++ b/mpt_extension_sdk/extension_app.py
@@ -203,16 +203,16 @@ class ExtensionApp:
 
     Attributes:
         prefix: Prefix applied to every route included in the extension app.
-        version: Extension metadata version.
+        version: Extension version.
         openapi: OpenAPI endpoint published by the runtime.
     """
 
     prefix: str = ""
     version: str = "6.0.0"
     openapi: str = "/bypass/openapi.json"
-    mpt_api_service_type: type[MPTAPIService] = MPTAPIService
-    order_context_type: type[ContextAdapter] | None = None
     agreement_context_type: type[ContextAdapter] | None = None
+    order_context_type: type[ContextAdapter] | None = None
+    mpt_api_service_type: type[MPTAPIService] = field(default=MPTAPIService)
     _routes: list[RouteDefinition] = field(default_factory=list, init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -267,7 +267,6 @@ class ExtensionApp:
     def to_meta_config(self) -> MetaConfig:
         """Build extension metadata from the registered application routes."""
         return MetaConfig(
-            version=self.version,
             openapi=self.openapi,
             events=[
                 MetaEvent(

--- a/mpt_extension_sdk/runtime/models.py
+++ b/mpt_extension_sdk/runtime/models.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Annotated, Any, Self
+from typing import Any, Self
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -11,9 +11,9 @@ class MetaEvent(BaseModel):
     """MetaEvent model for loading metadata."""
 
     # Keep the order of fields in the model consistent with the order in the metadata file
-    event: Annotated[str, Field(min_length=1)]
-    condition: Annotated[str | None, Field(min_length=1)] = None
-    path: Annotated[str, Field(min_length=1)]
+    event: str = Field(min_length=1)
+    condition: str | None = Field(default=None, min_length=1)
+    path: str = Field(min_length=1)
     task: bool
 
     model_config = ConfigDict(extra="forbid")
@@ -23,8 +23,8 @@ class MetaConfig(BaseModel):
     """MetaConfig model for loading metadata."""
 
     # Keep the order of fields in the model consistent with the order in the metadata file
-    version: Annotated[str, Field(min_length=1)]
-    openapi: Annotated[str, Field(min_length=1)]
+    openapi: str = Field(min_length=1)
+    version: str = Field(default="1.0.0", min_length=1)
 
     events: list[MetaEvent]
 

--- a/mpt_extension_sdk/settings/base.py
+++ b/mpt_extension_sdk/settings/base.py
@@ -31,13 +31,22 @@ class BaseSettings(ABC):
         return raw_value in frozenset(("true", "1", "yes"))
 
     @classmethod
-    def int_env(cls, env_key: str, default: int) -> int:
+    def int_env(cls, env_key: str, *, default: int) -> int:
         """Parse an integer environment variable and raise ConfigError on failure."""
         raw_value = os.getenv(env_key, str(default))
         try:
             return int(raw_value)
         except ValueError as error:
             raise ConfigError(f"Invalid integer in {env_key}: {raw_value}") from error
+
+    @classmethod
+    def list_env(cls, env_key: str, *, default: str = "") -> list[str]:
+        """Parse a str environment variable into a list."""
+        raw_values = os.getenv(env_key, default)
+        if not raw_values:
+            return []
+
+        return [raw_value.strip() for raw_value in raw_values.split(",") if raw_value.strip()]
 
     def validate(self) -> None:
         """Check required environment variables are not missing.

--- a/mpt_extension_sdk/settings/runtime.py
+++ b/mpt_extension_sdk/settings/runtime.py
@@ -80,10 +80,10 @@ class RuntimeSettings(BaseSettings):
             ),
             otel_service_name=os.getenv("SDK_OTEL_SERVICE_NAME", ""),
             local_host=os.getenv("SDK_LOCAL_HOST", "0.0.0.0"),  # noqa: S104
-            local_port=cls.int_env("SDK_LOCAL_PORT", DEFAULT_LOCAL_PORT),
+            local_port=cls.int_env("SDK_LOCAL_PORT", default=DEFAULT_LOCAL_PORT),
             local_reload=cls.bool_env("SDK_LOCAL_RELOAD", default=True),
-            local_workers=cls.int_env("SDK_LOCAL_WORKERS", 1),
-            ziti_workers=cls.int_env("SDK_ZITI_WORKERS", 4),
+            local_workers=cls.int_env("SDK_LOCAL_WORKERS", default=1),
+            ziti_workers=cls.int_env("SDK_ZITI_WORKERS", default=4),
             ziti_reload=cls.bool_env("SDK_ZITI_RELOAD", default=False),
         )
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -14,7 +14,7 @@ def cli_runner():
 
 
 @pytest.fixture
-def matching_meta():
+def meta():
     return MetaConfig(
         version="1.0.0",
         openapi="/bypass/openapi.json",
@@ -69,16 +69,14 @@ def test_meta_generate_writes_meta_file(runtime_settings_factory, cli_runner, mo
 
 
 def test_validate_succeeds_when_meta_matches(
-    runtime_settings_factory, cli_runner, matching_meta, mocker, tmp_path
+    runtime_settings_factory, cli_runner, meta, mocker, tmp_path
 ):
-    settings = runtime_settings_factory(
-        meta_config=matching_meta, meta_file_path=tmp_path / "meta.yaml"
-    )
+    settings = runtime_settings_factory(meta_config=meta, meta_file_path=tmp_path / "meta.yaml")
     mocker.patch(
         "mpt_extension_sdk.cli.main.RuntimeSettings.load", autospec=True, return_value=settings
     )
     mocker.patch(
-        "mpt_extension_sdk.cli.main.MetaConfig.from_file", autospec=True, return_value=matching_meta
+        "mpt_extension_sdk.cli.main.MetaConfig.from_file", autospec=True, return_value=meta
     )
 
     result = cli_runner.invoke(app, ["meta", "validate"])

--- a/tests/settings/test_base.py
+++ b/tests/settings/test_base.py
@@ -1,0 +1,51 @@
+import pytest
+
+from mpt_extension_sdk.settings.base import BaseSettings
+
+
+@pytest.mark.parametrize(("env_value", "expected"), [("True", True), ("False", False)])
+def test_base_settings_bool_env_vars(env_value, expected, monkeypatch):
+    monkeypatch.setenv("TEST_ENV_BOOL", env_value)
+
+    result = BaseSettings.bool_env("TEST_ENV_BOOL", default=False)
+
+    assert result is expected
+    assert isinstance(result, bool)
+
+
+@pytest.mark.parametrize(("env_value", "expected"), [("123", 123), ("0", 0)])
+def test_base_settings_int_env_vars(env_value, expected, monkeypatch):
+    monkeypatch.setenv("TEST_ENV_INT", env_value)
+
+    result = BaseSettings.int_env("TEST_ENV_INT", default=0)
+
+    assert result == expected
+    assert isinstance(result, int)
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        ("PRD-1", ["PRD-1"]),
+        ("PRD-1, PRD-2", ["PRD-1", "PRD-2"]),
+        ("PRD-1,PRD-2", ["PRD-1", "PRD-2"]),
+        ("PRD-1, ,PRD-2", ["PRD-1", "PRD-2"]),
+        ("", []),
+    ],
+)
+def test_base_settings_list_env_vars(env_value, expected, monkeypatch):
+    monkeypatch.setenv("TEST_ENV_LIST", env_value)
+
+    result = BaseSettings.list_env("TEST_ENV_LIST")
+
+    assert result == expected
+    assert isinstance(result, list)
+
+
+def test_base_settings_list_env_vars_unset(monkeypatch):
+    monkeypatch.delenv("TEST_ENV_LIST", raising=False)
+
+    result = BaseSettings.list_env("TEST_ENV_LIST")
+
+    assert result == []
+    assert isinstance(result, list)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20495](https://softwareone.atlassian.net/browse/MPT-20495)

- Make MetaConfig.version optional with default "1.0.0" (no longer required)
- Stop propagating ExtensionApp.version into generated MetaConfig (to_meta_config no longer sets version)
- Simplify Pydantic field constraints in runtime models (remove typing.Annotated, use Field directly)
- Convert ExtensionSettings to a frozen dataclass and add product_ids (read from MPT_PRODUCTS_IDS via new BaseSettings.list_env)
- Add BaseSettings.list_env; make int_env require default as keyword-only; add tests for bool/int/list env parsing
- Update RuntimeSettings.load to call int_env with keyword default arguments for SDK_* integers
- Adjust ExtensionApp dataclass field declaration for mpt_api_service_type (use field(default=...)) and validate service type on use
- Demo compose: remove commented .env reference, keep .env.demo
- Tests: rename metadata fixture usage from matching_meta → meta and update related test calls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20495]: https://softwareone.atlassian.net/browse/MPT-20495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ