### PR TITLE
MPT-20495: improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The repository contains:
 - public SDK primitives centered on `ExtensionApp`, `ExtensionRouter`, and typed execution contexts
 - FastAPI runtime wiring for event handlers, task-backed routes, local development (`FastAPI + uvicorn`), and platform execution (`mrok`/`ziticorn`)
 - shared Marketplace service clients, settings discovery, observability hooks, and pipeline helpers
+- a Typer-based `mpt-ext` CLI for runtime startup and metadata generation/validation
 - repository tooling and documentation for building and validating the SDK itself
 
 ## Documentation

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,7 @@ The main package lives under [`mpt_extension_sdk/`](../mpt_extension_sdk).
 - [`mpt_extension_sdk/runtime/main.py`](../mpt_extension_sdk/runtime/main.py): exports the ASGI application instance
 - [`mpt_extension_sdk/runtime/runner.py`](../mpt_extension_sdk/runtime/runner.py): runs the extension locally with `uvicorn` or on the platform with `ziticorn`
 - [`mpt_extension_sdk/settings/runtime.py`](../mpt_extension_sdk/settings/runtime.py): discovers runtime configuration, metadata, and extension package entrypoints
+- [`mpt_extension_sdk/settings/extension.py`](../mpt_extension_sdk/settings/extension.py): discovers `<package>.settings.ExtensionSettings`
 
 ## Runtime Model
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,9 @@ working directory. It expects exactly one top-level package that exports:
 - `app.py` with `ext_app`
 - `settings.py` with `ExtensionSettings`
 
+`ExtensionSettings` must inherit from
+`mpt_extension_sdk.settings.extension.BaseExtensionSettings`.
+
 The runtime then derives:
 
 - `app_module` as `<package>.app`
@@ -66,6 +69,9 @@ LOG_LEVEL=INFO
 - [`mpt_extension_sdk/settings/runtime.py`](../mpt_extension_sdk/settings/runtime.py)
   loads runtime configuration from environment variables and auto-discovers the
   extension package.
+- `RuntimeSettings` validates `SDK_EXTENSION_URL`, `SDK_EXTENSION_API_KEY`,
+  `SDK_EXTENSION_ID`, `MPT_API_BASE_URL`, and `MPT_API_TOKEN` as required
+  environment variables.
 - [`mpt_extension_sdk/runtime/runner.py`](../mpt_extension_sdk/runtime/runner.py)
   writes `meta.yaml` before startup and selects Uvicorn or Ziticorn depending
   on the CLI mode.
@@ -78,8 +84,8 @@ LOG_LEVEL=INFO
 
 ## Observability
 
-Observability is configured through the SDK runtime settings instead of Django
-settings. A typical setup includes:
+Observability is configured through the SDK runtime settings. A typical setup
+includes:
 
 ```bash
 SDK_OBSERVABILITY_ENABLED=true
@@ -87,9 +93,17 @@ SDK_APPLICATIONINSIGHTS_CONNECTION_STRING=InstrumentationKey=...
 SDK_OTEL_SERVICE_NAME=my-extension
 ```
 
-When observability is enabled, the SDK instruments FastAPI requests and HTTPX
-client calls. SDK event spans are attached to the active request trace so
-request, handler, and outbound-call spans stay in the same hierarchy.
+When observability is enabled, the SDK bootstraps:
+
+- FastAPI instrumentation
+- HTTPX client instrumentation
+- logging correlation through OpenTelemetry logging instrumentation
+- OTLP exporting by default
+- Azure Monitor exporting when `SDK_APPLICATIONINSIGHTS_CONNECTION_STRING` is set
+
+OpenTelemetry exporter-specific variables such as
+`OTEL_EXPORTER_OTLP_ENDPOINT` are read by the underlying OpenTelemetry
+exporter, not by `RuntimeSettings` directly.
 
 Document additional repository-specific configuration here when SDK runtime
 requirements expand.

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -57,13 +57,13 @@ Common examples:
 mpt-ext run --local
 mpt-ext run
 mpt-ext meta generate
-mpt-ext validate
+mpt-ext meta validate
 ```
 
 - `mpt-ext run --local` starts the FastAPI + uvicorn runtime for local development.
 - `mpt-ext run` performs extension registration and starts mrok/ziticorn.
 - `mpt-ext meta generate` writes the metadata file generated from `ext_app`.
-- `mpt-ext validate` checks the checked-in metadata artifact against generated output.
+- `mpt-ext meta validate` checks the checked-in metadata artifact against generated output.
 
 ## Packaging
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -14,29 +14,11 @@ The `migrations` topic here covers SDK compatibility changes that require consum
 
 ## Current Migration Notes
 
-### API Base URL Change
+There are no repository-specific SDK migration notes at the moment.
 
-The SDK now standardizes Marketplace API requests on `/public/v1/`.
-
-Repository-specific guidance:
-
-- `MPTClient` appends `/public/v1/` to the configured base URL
-- `MPT_API_BASE_URL` should not include `/v1` or `/public/v1`
-- older configurations remain accepted for backward compatibility, but they are legacy input forms
-- legacy inputs still resolve to the standardized final API path
-
-Use:
-
-```bash
-export MPT_API_BASE_URL=https://api.example.com
-```
-
-Do not use:
-
-```bash
-export MPT_API_BASE_URL=https://api.example.com/v1
-```
-
+Add a section here only when this repository introduces a consumer-facing
+compatibility change that requires upgrade guidance.
 ## When To Update This Document
 
-Update this file when the SDK introduces a consumer-facing compatibility change that requires upgrade guidance.
+Update this file when the SDK introduces a consumer-facing compatibility change
+that requires upgrade guidance.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,25 +12,17 @@ needed.
 
 ## Test Scope
 
-The repository currently has pytest configured in [`pyproject.toml`](../pyproject.toml),
-but the `tests/` tree is not yet populated with stable domain coverage.
+The repository has pytest configured in [`pyproject.toml`](../pyproject.toml)
+and the `tests/` tree already covers the main SDK domains, including:
 
-When adding coverage, organize tests by SDK domain, for example:
-
-- extension app and route registration under `tests/extension_app/` or equivalent
+- extension app and route registration under `tests/test_extension_app.py`
 - pipeline contexts, decorators, and factories under `tests/pipeline/`
 - runtime app, runner, and bootstrap behavior under `tests/runtime/`
 - Marketplace service helpers under `tests/services/`
 - CLI behavior under `tests/cli/`
+- settings loading under `tests/settings/`
+- observability bootstrap and tracing under `tests/observability/`
 
-Shared unit-test scope also applies:
-
-- use `pytest` for unit tests
-- write tests as functions, not classes
-- do not add type annotations to test functions
-- keep test files and test functions under the `test_` naming convention
-- do not add test docstrings
-- keep the `tests/` layout aligned with the source layout
 
 ## Commands
 
@@ -72,17 +64,11 @@ Repository-specific test settings come from [`pyproject.toml`](../pyproject.toml
 Repository-specific guidance:
 
 - add or update tests next to the affected SDK domain instead of creating catch-all files
+- prefer existing fixtures from [`tests/conftest.py`](../tests/conftest.py) and domain-specific `conftest.py` files
 - keep external service calls mocked; do not make live Marketplace or external platform calls in tests
-- cover public SDK behavior when changing `ExtensionApp`, `ExtensionRouter`, pipeline APIs, or runtime wiring
 - cover CLI and runtime changes under `tests/cli/` or `tests/runtime/`
-- prefer smoke and regression tests for imports, route registration, context building, and startup flows before broadening coverage
+- cover public SDK behavior when changing `ExtensionApp`, `ExtensionRouter`, pipeline APIs, or runtime wiring
 
-Shared unit-test rules that must be followed in this repository:
-
-- follow AAA (Arrange, Act, Assert); keep the act step explicit and easy to spot
-- do not put branching logic inside tests; use `@pytest.mark.parametrize` for permutations
-- prefer a single logical assertion per test; if several assertions validate one result object, keep them tightly related
-- test branches as close as possible to the function where the branch exists
 
 ## When Tests Are Required
 
@@ -95,19 +81,3 @@ Add or update tests when a change modifies:
 - observability, middleware, or settings-loading behavior
 
 If a change only affects documentation, tests are not required.
-
-## Validation Flow
-
-The shared build-and-checks workflow applies here with repository-specific
-targets:
-
-1. Run `make build` if `uv.lock` changed.
-2. Then run `make check-all`.
-
-These commands are expected to run sequentially in that order.
-
-Before committing:
-
-- make sure `pre-commit` is installed or updated locally
-- review the automatic `pre-commit` output during `git commit`
-- treat the commit as incomplete until the hooks pass cleanly

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,6 +1,6 @@
 # SDK Usage
 
-This guide shows how to build on top of `mpt-extension-sdk`.
+This guide shows how to build an extension package on top of `mpt-extension-sdk`.
 
 ## Install The SDK
 
@@ -14,79 +14,91 @@ pip install mpt-extension-sdk
 uv add mpt-extension-sdk
 ```
 
+## Extension Package Shape
+
+The runtime auto-discovers exactly one top-level package in the working directory. That package
+must export:
+
+- `app.py` with `ext_app`
+- `settings.py` with `ExtensionSettings`
+
+`ExtensionSettings` must inherit from
+`mpt_extension_sdk.settings.extension.BaseExtensionSettings`.
+
+Keep imports in `app.py` deterministic. The runtime imports `ext_app` to build
+metadata before startup, so avoid network calls, filesystem I/O, or other heavy
+side effects at module import time.
+
 ## Create An Extension App
 
 Start with `ExtensionApp` and `ExtensionRouter`. The extension app is the root
 SDK object for one extension package. Routers group related event handlers and
-expose metadata consumed by the runtime.
+their route metadata before they are included in the app.
 
 ```python
-# app.py
-from mpt_extension_sdk.extension_app import ExtensionApp
+# mock_app/app.py
+from mpt_extension_sdk import ExtensionApp
 
 from mock_app.api.routes import orders_router
 
-ext_app = ExtensionApp(prefix="/api/v1")
+ext_app = ExtensionApp(prefix="/api/v2")
 ext_app.include_router(orders_router)
 ```
 
 ```python
-# api/routes.py
-from mpt_extension_sdk.extension_app import ExtensionRouter
+# mock_app/api/routes.py
+from mpt_extension_sdk import ExtensionRouter
+
+orders_router = ExtensionRouter(prefix="/events/orders")
+```
+
+## Register Handlers
+
+Use `route(...)` for non-task events:
+
+```python
+from mpt_extension_sdk import ExtensionRouter
 
 orders_router = ExtensionRouter(prefix="/events/orders")
 
 
 @orders_router.route(
-    path="/purchase", name="orders-purchase", event="platform.commerce.order.status_changed"
+    path="/purchase",
+    name="orders-purchase",
+    event="platform.commerce.order.purchased",
 )
-async def process_order(event, context):
-    """Process order events."""
+async def process_purchase(event, context):
+    """Process a non-task order event."""
 ```
 
-Keep `app.py` imports deterministic. The runtime imports the exported
-`ext_app` during metadata generation, so avoid network calls, filesystem I/O,
-or other heavy side effects at module import time.
-
-## Register Handlers
-
-Use `route(...)` when the platform event is non-task-based.
+Use `task_route(...)` for task-backed events. The runtime starts, completes,
+fails, or reschedules the Marketplace task around the handler execution.
 
 ```python
-from mpt_extension_sdk.extension_app import ExtensionRouter
-
-orders_router = ExtensionRouter(prefix="/events/orders")
-
-
-@orders_router.route(path="/change", name="orders-change", event="platform.commerce.order.created")
-async def process_order_change(event, context):
-    """Process a task-backed order event."""
-```
-
-
-Use `task_route(...)` when the platform event is task-backed and the runtime
-must manage task lifecycle operations.
-
-```python
-from mpt_extension_sdk.extension_app import ExtensionRouter
+from mpt_extension_sdk import ExtensionRouter
 
 orders_router = ExtensionRouter(prefix="/events/orders")
 
 
 @orders_router.task_route(
-    path="/change", name="orders-change", event="platform.commerce.order.created"
+    path="/change",
+    name="orders-change",
+    event="platform.commerce.order.created",
 )
 async def process_order_change(event, context):
     """Process a task-backed order event."""
 ```
 
+Within one router or app, each route `name`, `path`, and `event` must be
+unique.
+
 ## Build A Processing Pipeline
 
-Use `BasePipeline`, `BaseStep`, and execution contexts for multi-step
+Use `BasePipeline`, `BaseStep`, and typed execution contexts for multi-step
 processing flows.
 
 ```python
-from typing import Self, override
+from typing import override
 
 from mpt_extension_sdk.pipeline import BasePipeline, BaseStep, OrderContext
 
@@ -108,10 +120,15 @@ class PurchasePipeline(BasePipeline):
         return [ValidateOrderStep(), ProcessOrderStep()]
 ```
 
+The SDK exports both `OrderContext` and `AgreementContext`, and the runtime
+hydrates the right one from `event.object.object_type`.
+
 ## Adapt The Execution Context
 
-Use `ContextAdapter` when an extension needs a custom context type built from
-the SDK-provided base context.
+Use a context factory when an extension needs to enrich the SDK-provided
+context with extension-specific fields or dependencies. The factory must return
+the same context family it receives, for example `OrderContext` or a subclass
+of it.
 
 ```python
 from dataclasses import dataclass, field
@@ -144,13 +161,12 @@ mpt-ext meta generate
 mpt-ext meta validate
 ```
 
-- `mpt-ext run --local` starts the FastAPI + uvicorn runtime for local development.
-- `mpt-ext run` generates `meta.yaml`, registers the extension instance, and starts
-  the platform runtime with mrok/ziticorn.
-- `mpt-ext meta generate` writes the metadata artifact derived from the exported
-  `ext_app`.
-- `mpt-ext meta validate` checks that the checked-in `meta.yaml` matches the generated
-  metadata.
+- `mpt-ext run --local` starts the local `FastAPI + uvicorn` runtime.
+- `mpt-ext run` writes `meta.yaml`, registers the extension instance, and starts
+  the platform runtime with `mrok`/`ziticorn`.
+- `mpt-ext meta generate` writes metadata derived from `ext_app.to_meta_config()`.
+- `mpt-ext meta validate` compares the checked-in `meta.yaml` with generated
+  metadata and writes `meta.generated.yaml` when they differ.
 
 ## Configure The Runtime
 
@@ -212,12 +228,9 @@ class UpdateOrderStep(BaseStep):
         )
 ```
 
-This keeps partial updates flexible for extension-specific fields while still
-making status transitions explicit in the SDK API.
-
 ## What The SDK Provides
 
-- `ExtensionApp` and `ExtensionRouter` for extension registration and route metadata
-- FastAPI + uvicorn runtime wiring for task and non-task Marketplace events
-- typed execution contexts, context adapters, and pipeline primitives
-- Marketplace service helpers, runtime settings discovery, and observability hooks
+- `ExtensionApp` and `ExtensionRouter` for route registration and metadata
+- task and non-task FastAPI runtime wiring
+- typed execution contexts, context factories, and pipeline primitives
+- Marketplace service helpers, settings discovery, and observability hooks


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20495](https://softwareone.atlassian.net/browse/MPT-20495)

- README: Added Typer-based `mpt-ext` CLI entry describing runtime startup and metadata generation/validation
- docs/architecture.md: Documented `mpt_extension_sdk/settings/extension.py` as a main entry point for discovering `<package>.settings.ExtensionSettings`
- docs/configuration.md: Mandated `ExtensionSettings` inherit from `BaseExtensionSettings`; documented required RuntimeSettings environment variables (SDK_EXTENSION_URL, SDK_EXTENSION_API_KEY, SDK_EXTENSION_ID, MPT_API_BASE_URL, MPT_API_TOKEN); clarified observability bootstrap behavior and that exporter-specific OTEL variables are consumed by underlying exporters
- docs/local-development.md: Updated CLI examples and guidance to use `mpt-ext meta validate` (and `mpt-ext meta generate`) for metadata operations
- docs/migrations.md: Removed repository-specific migration notes and left a placeholder stating no current SDK migration notes
- docs/testing.md: Expanded test coverage catalog to include settings-loading and observability tracing; added directive to prefer existing shared/domain fixtures and simplified local testing guidance
- docs/usage.md: Added "Extension Package Shape" (one top-level package, required exports `ext_app` and `ExtensionSettings`), required base-class for `ExtensionSettings`, clarified deterministic imports for `app.py`; updated route/handler and task semantics, introduced context factory/typed execution context wording, described runtime metadata commands (`ext_app.to_meta_config()`, `meta.generated.yaml`), and tightened various SDK-provided feature descriptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20495]: https://softwareone.atlassian.net/browse/MPT-20495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ