### PR TITLE
MPT-20734: add plug router metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ When applicable, read the repository in this order:
 Then inspect the code paths relevant to the task:
 
 - [`mpt_extension_sdk/extension_app.py`](mpt_extension_sdk/extension_app.py): public SDK entrypoint that defines `ExtensionApp`, `ExtensionRouter`, route registration, and context adaptation
-- [`mpt_extension_sdk/api/router.py`](mpt_extension_sdk/api/router.py): FastAPI route builders for task and non-task handlers, event execution, and task lifecycle wiring
+- [`mpt_extension_sdk/api/builders/`](mpt_extension_sdk/api/builders): FastAPI route builders for API/event handlers, argument resolution, execution, and error mapping
 - [`mpt_extension_sdk/pipeline/`](mpt_extension_sdk/pipeline): execution contexts, pipeline primitives, step decorators, and context factory helpers
 - [`mpt_extension_sdk/runtime/app.py`](mpt_extension_sdk/runtime/app.py): FastAPI app assembly, middleware registration, observability bootstrap, and extension route mounting
 - [`mpt_extension_sdk/runtime/main.py`](mpt_extension_sdk/runtime/main.py): exported ASGI application used by local and platform runtimes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,12 +57,16 @@ The SDK runtime has two main execution surfaces:
 - local development through `FastAPI + uvicorn`
 - platform execution through `mrok`/`ziticorn`, after extension registration and identity bootstrap
 
-`runtime/runner.py` generates `meta.yaml` before startup. In platform mode it registers the extension instance, persists the returned identity when present, and starts the exported ASGI app through Ziticorn. `runtime/app.py` assembles the FastAPI app, configures middleware and observability, loads the extension's exported `ext_app`, and mounts every registered route.
+`runtime/runner.py` generates `meta.yaml` before startup. In platform mode it registers the extension instance,
+persists the returned identity when present, and starts the exported ASGI app through Ziticorn.
+`runtime/app.py` assembles the FastAPI app, configures middleware and observability,
+loads the extension's exported `ext_app`, and mounts every registered route.
 
 At the moment, `event` and `api` route families are implemented end-to-end in
-runtime request handling. Event routes are also emitted into `meta.yaml`.
-`schedule` and `plug` route families are modeled in the SDK contract but are
-not yet mounted by the runtime or emitted into `meta.yaml`.
+runtime request handling. Event routes are also emitted into `meta.yaml`. The
+`plug` route family is implemented as declarative metadata with static asset
+exposure under `/static`. The `schedule` route family is modeled in the SDK
+contract but is not yet mounted by the runtime or emitted into `meta.yaml`.
 
 ## Boundaries
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,9 +52,10 @@ orders_router = EventRouter(prefix="/events/orders")
 ```
 
 The SDK also exposes `APIRouter`, `ScheduleRouter`, and `PlugRouter`.
-`EventRouter` and `APIRouter` are mounted by the runtime. `ScheduleRouter` and
-`PlugRouter` are modeled in the SDK contract but are not yet mounted by the
-runtime or emitted into metadata.
+`EventRouter` and `APIRouter` are mounted by the runtime. `PlugRouter` is
+declarative: its plug definitions are emitted into metadata and its static
+assets are exposed through `/static`. `ScheduleRouter` is modeled in the SDK
+contract but is not yet mounted by the runtime or emitted into metadata.
 
 ## Register Event Handlers
 
@@ -138,6 +139,47 @@ agreements_api = APIRouter(prefix="/agreements")
 async def sync_agreement(agreement_id: str, payload: SyncAgreementPayload, ctx):
     return APIResponse.accepted(payload={"id": agreement_id, "status": payload.status})
 ```
+
+## Register UI Plugs
+
+Use `PlugRouter` to declare widgets that MPT can register during extension
+instance registration. Plug definitions are metadata only; the SDK does not
+build or render frontend assets.
+
+```python
+from mpt_extension_sdk import ExtensionApp, Plug, PlugRouter
+
+plug_router = PlugRouter()
+
+
+@plug_router.register()
+def register_plugs() -> list[Plug]:
+    return [
+        Plug(
+            id="adobe",
+            name="Adobe",
+            description="Adobe widget",
+            icon="adobe.png",
+            socket="commerce.agreements.agreement",
+            condition="eq(product.id,'PRD-1234-5677')",
+            href="main-menu.js",
+        )
+    ]
+
+
+ext_app = ExtensionApp(prefix="/")
+ext_app.include_router(plug_router)
+```
+
+The `PlugRouter` instance named `plug_router` owns the `register_plugs`
+provider until `ExtensionApp.include_router` attaches it to the extension app.
+
+`href` and `icon` should be filenames or paths relative to the local `static/`
+folder, such as `main-menu.js` or `images/icon.png`. The SDK normalizes them
+under `/static/` in generated metadata, so `href="main-menu.js"` becomes
+`/static/main-menu.js` and `icon="images/icon.png"` becomes
+`/static/images/icon.png`. The `mpt-ext meta validate` command checks that every
+referenced file exists locally.
 
 ## Event Context Resolution
 
@@ -238,7 +280,8 @@ mpt-ext meta validate
   the platform runtime with `mrok`/`ziticorn`.
 - `mpt-ext meta generate` writes metadata derived from `ext_app.to_meta_config()`.
 - `mpt-ext meta validate` compares the checked-in `meta.yaml` with generated
-  metadata and writes `meta.generated.yaml` when they differ.
+  metadata, validates plug static assets, and writes `meta.generated.yaml` when
+  validation fails.
 
 ## Configure The Runtime
 

--- a/mpt_extension_sdk/__init__.py
+++ b/mpt_extension_sdk/__init__.py
@@ -1,10 +1,11 @@
 from mpt_extension_sdk.extension_app import ExtensionApp
-from mpt_extension_sdk.routing import APIRouter, EventRouter, PlugRouter, ScheduleRouter
+from mpt_extension_sdk.routing import APIRouter, EventRouter, Plug, PlugRouter, ScheduleRouter
 
 __all__ = [  # noqa: WPS410
     "APIRouter",
     "EventRouter",
     "ExtensionApp",
+    "Plug",
     "PlugRouter",
     "ScheduleRouter",
 ]

--- a/mpt_extension_sdk/cli/main.py
+++ b/mpt_extension_sdk/cli/main.py
@@ -1,8 +1,10 @@
+from pathlib import Path
 from typing import Annotated
 
 import typer
 
 from mpt_extension_sdk.errors.runtime import ConfigError
+from mpt_extension_sdk.routing import STATIC_PATH_PREFIX
 from mpt_extension_sdk.runtime.models import MetaConfig
 from mpt_extension_sdk.runtime.runner import run_extension
 from mpt_extension_sdk.settings.runtime import RuntimeSettings
@@ -34,11 +36,19 @@ def generate_meta() -> None:
 
 
 @meta_app.command()
-def validate() -> None:
+def validate() -> None:  # noqa: WPS213
     """Validate that the generated metadata matches the checked-in file."""
     runtime_settings = RuntimeSettings.load()
     generated_meta = runtime_settings.meta_config
     generated_path = runtime_settings.meta_file_path.with_name("meta.generated.yaml")
+    try:
+        validate_plug_static_assets(generated_meta)
+    except ConfigError as error:
+        generated_meta.to_file(generated_path)
+        typer.secho(f"Invalid plug static assets: {error}", err=True, fg=typer.colors.RED)
+        typer.secho(f"Generated file written to: {generated_path}", err=True)
+        raise typer.Exit(code=1) from None
+
     try:
         checked_in_meta = MetaConfig.from_file(runtime_settings.meta_file_path)
     except ConfigError as error:
@@ -58,6 +68,29 @@ def validate() -> None:
         raise typer.Exit(code=1)
 
     typer.echo(f"Metadata is valid: {runtime_settings.meta_file_path}")
+
+
+def validate_plug_static_assets(meta_config: MetaConfig, static_root: Path | None = None) -> None:
+    """Validate local static assets referenced by registered plugs."""
+    asset_root = static_root or Path.cwd() / "static"
+    for plug in getattr(meta_config, "plugs", None) or []:
+        _validate_static_asset(plug.href, asset_root)
+        if plug.icon is not None:
+            _validate_static_asset(plug.icon, asset_root)
+
+
+def _validate_static_asset(asset_path: str, static_root: Path) -> None:
+    """Validate that a metadata asset path resolves under the local static folder."""
+    if not asset_path.startswith(STATIC_PATH_PREFIX):
+        raise ConfigError(f"Plug asset path must start with {STATIC_PATH_PREFIX}: {asset_path}")
+
+    relative_asset_path = asset_path.removeprefix(STATIC_PATH_PREFIX)
+    resolved_root = static_root.resolve()
+    resolved_asset = (resolved_root / relative_asset_path).resolve()
+    if not resolved_asset.is_relative_to(resolved_root):
+        raise ConfigError(f"Plug asset path escapes static folder: {asset_path}")
+    if not resolved_asset.is_file():
+        raise ConfigError(f"Plug asset file was not found: {asset_path}")
 
 
 @app.callback()

--- a/mpt_extension_sdk/extension_app.py
+++ b/mpt_extension_sdk/extension_app.py
@@ -8,7 +8,8 @@ from mpt_extension_sdk.routing import (
     EventRouteDefinition,
 )
 from mpt_extension_sdk.routing.routers.base import BaseExtensionRouter
-from mpt_extension_sdk.runtime.models import MetaConfig, MetaEvent
+from mpt_extension_sdk.runtime.builders import PlugMetadataBuilder
+from mpt_extension_sdk.runtime.models import MetaConfig, MetaEvent, MetaPlug
 from mpt_extension_sdk.services.mpt_api_service import MPTAPIService
 
 
@@ -65,4 +66,9 @@ class ExtensionApp:
                 for route in self._routes
                 if isinstance(route, EventRouteDefinition)
             ],
+            plugs=self._build_meta_plugs() or None,
         )
+
+    def _build_meta_plugs(self) -> list[MetaPlug]:
+        """Build plug metadata from registered plug providers."""
+        return PlugMetadataBuilder(routes=self._routes).build()

--- a/mpt_extension_sdk/routing/__init__.py
+++ b/mpt_extension_sdk/routing/__init__.py
@@ -6,14 +6,16 @@ from mpt_extension_sdk.routing.models import (
     PlugRouteDefinition,
     ScheduleRouteDefinition,
 )
+from mpt_extension_sdk.routing.plugs import STATIC_PATH_PREFIX, Plug
 from mpt_extension_sdk.routing.routers.api import APIRouter
 from mpt_extension_sdk.routing.routers.base import BaseExtensionRouter
 from mpt_extension_sdk.routing.routers.event import EventRouter
 from mpt_extension_sdk.routing.routers.plug import PlugRouter
 from mpt_extension_sdk.routing.routers.schedule import ScheduleRouter
-from mpt_extension_sdk.routing.types import APIRouteCallback, EventRouteCallback
+from mpt_extension_sdk.routing.types import APIRouteCallback, EventRouteCallback, PlugRouteCallback
 
 __all__ = [  # noqa: WPS410
+    "STATIC_PATH_PREFIX",
     "APIRouteCallback",
     "APIRouteDefinition",
     "APIRouter",
@@ -24,6 +26,8 @@ __all__ = [  # noqa: WPS410
     "EventRouteDefinition",
     "EventRouter",
     "HTTPMethod",
+    "Plug",
+    "PlugRouteCallback",
     "PlugRouteDefinition",
     "PlugRouter",
     "RouteType",

--- a/mpt_extension_sdk/routing/models.py
+++ b/mpt_extension_sdk/routing/models.py
@@ -2,7 +2,12 @@ from dataclasses import dataclass
 
 from mpt_extension_sdk.context import ContextAdapter
 from mpt_extension_sdk.routing.enums import EventDeliveryMode, HTTPMethod, RouteType
-from mpt_extension_sdk.routing.types import APIRouteCallback, EventRouteCallback, RouteCallback
+from mpt_extension_sdk.routing.types import (
+    APIRouteCallback,
+    EventRouteCallback,
+    PlugRouteCallback,
+    RouteCallback,
+)
 from mpt_extension_sdk.schemas import BaseSchema
 
 
@@ -44,3 +49,5 @@ class ScheduleRouteDefinition(BaseRouteDefinition):
 @dataclass(frozen=True)
 class PlugRouteDefinition(BaseRouteDefinition):
     """Route definition for plug handlers."""
+
+    callback: PlugRouteCallback

--- a/mpt_extension_sdk/routing/plugs.py
+++ b/mpt_extension_sdk/routing/plugs.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+STATIC_PATH_PREFIX = "/static/"
+
+
+@dataclass(frozen=True)
+class Plug:
+    """UI plug metadata declared by an extension."""
+
+    id: str
+    name: str
+    description: str
+    socket: str
+    href: str
+    icon: str | None = None
+    condition: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate and normalize static asset references."""
+        self._validate_required_fields()
+        object.__setattr__(self, "href", self.normalize_static_path(self.href))
+        if self.icon is not None:
+            object.__setattr__(self, "icon", self.normalize_static_path(self.icon))
+
+    @classmethod
+    def normalize_static_path(cls, path: str) -> str:
+        """Return a plug asset path rooted under the public static route."""
+        cleaned_path = path.strip()
+        if not cleaned_path:
+            raise ValueError("Plug static asset path cannot be empty")
+
+        static_root = STATIC_PATH_PREFIX.removesuffix("/")
+        if cleaned_path in {static_root, STATIC_PATH_PREFIX}:
+            raise ValueError("Plug static asset path must include a file")
+
+        if cleaned_path.startswith(STATIC_PATH_PREFIX):
+            relative_path = cleaned_path.removeprefix(STATIC_PATH_PREFIX)
+        else:
+            relative_path = cleaned_path.lstrip("/")
+
+        path_parts = PurePosixPath(relative_path).parts
+        if not path_parts or cls._has_invalid_path_parts(path_parts):
+            raise ValueError("Plug static asset path must stay under the static folder")
+
+        return STATIC_PATH_PREFIX + PurePosixPath(*path_parts).as_posix()
+
+    @classmethod
+    def _has_invalid_path_parts(cls, path_parts: tuple[str, ...]) -> bool:
+        """Return whether a static asset path contains unsafe parts."""
+        return bool({"", ".", ".."}.intersection(path_parts))
+
+    def _validate_required_fields(self) -> None:
+        """Validate required plug fields."""
+        required_fields = {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "socket": self.socket,
+            "href": self.href,
+        }
+        for field_name, field_value in required_fields.items():
+            if not field_value.strip():
+                raise ValueError(f"Plug {field_name} cannot be empty")
+        if self.condition is not None and not self.condition.strip():
+            raise ValueError("Plug condition cannot be empty")

--- a/mpt_extension_sdk/routing/routers/plug.py
+++ b/mpt_extension_sdk/routing/routers/plug.py
@@ -4,26 +4,25 @@ from dataclasses import dataclass
 from mpt_extension_sdk.routing.enums import RouteType
 from mpt_extension_sdk.routing.models import PlugRouteDefinition
 from mpt_extension_sdk.routing.routers.base import BaseExtensionRouter
-from mpt_extension_sdk.routing.types import RouteCallback
+from mpt_extension_sdk.routing.types import PlugRouteCallback
 
 
 @dataclass
 class PlugRouter(BaseExtensionRouter):
     """Router object for static plug handlers."""
 
-    def plug(self, path: str, name: str) -> Callable[[RouteCallback], RouteCallback]:
-        """Register a plug handler."""
-        normalized_path = self._join_paths(self.prefix, path)
+    def register(self) -> Callable[[PlugRouteCallback], PlugRouteCallback]:
+        """Register a plug metadata provider."""
 
-        def decorator(route_handler: RouteCallback) -> RouteCallback:
+        def decorator(plug_provider: PlugRouteCallback) -> PlugRouteCallback:
             self._register_base_route(
                 PlugRouteDefinition(
-                    name=name,
-                    path=normalized_path,
+                    name=plug_provider.__name__,
+                    path=self._join_paths(self.prefix, plug_provider.__name__),
                     route_type=RouteType.PLUG,
-                    callback=route_handler,
+                    callback=plug_provider,
                 )
             )
-            return route_handler
+            return plug_provider
 
         return decorator

--- a/mpt_extension_sdk/routing/types.py
+++ b/mpt_extension_sdk/routing/types.py
@@ -1,6 +1,10 @@
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from mpt_extension_sdk.routing.plugs import Plug
 
 RouteCallback = Callable[..., Awaitable[Any] | Any]
 EventRouteCallback = Callable[..., Awaitable[None] | None]
 APIRouteCallback = Callable[..., Awaitable[object] | object]
+PlugRouteCallback = Callable[[], list["Plug"]]

--- a/mpt_extension_sdk/runtime/app.py
+++ b/mpt_extension_sdk/runtime/app.py
@@ -1,8 +1,10 @@
 import logging
 from collections.abc import Awaitable, Callable
 from importlib import import_module
+from pathlib import Path
 
 from fastapi import FastAPI, Request, Response
+from fastapi.staticfiles import StaticFiles
 
 from mpt_extension_sdk.api.builders.api import create_api_route
 from mpt_extension_sdk.api.builders.event import create_event_route
@@ -10,7 +12,11 @@ from mpt_extension_sdk.errors.runtime import ConfigError
 from mpt_extension_sdk.extension_app import ExtensionApp
 from mpt_extension_sdk.observability.bootstrap import ObservabilityBootstrap
 from mpt_extension_sdk.observability.config import ObservabilityConfig
-from mpt_extension_sdk.routing.models import APIRouteDefinition, EventRouteDefinition
+from mpt_extension_sdk.routing.models import (
+    APIRouteDefinition,
+    EventRouteDefinition,
+    PlugRouteDefinition,
+)
 from mpt_extension_sdk.runtime.logging import correlation_id_ctx, setup_logging, task_id_ctx
 from mpt_extension_sdk.settings.runtime import RuntimeSettings
 
@@ -63,11 +69,16 @@ def create_runtime_app(runtime_settings: RuntimeSettings) -> FastAPI:
     _configure_observability(app, observability_config)
     _configure_middlewares(app)
     _register_builtin_routes(app)
+    app.mount(
+        "/static",
+        StaticFiles(directory=Path.cwd() / "static", check_dir=False),
+        name="static",
+    )
     register_extension_routes(app, extension_app)
     return app
 
 
-def register_extension_routes(app: FastAPI, extension_app: ExtensionApp) -> None:
+def register_extension_routes(app: FastAPI, extension_app: ExtensionApp) -> None:  # noqa: WPS231
     """Register all decorated handlers on the FastAPI app.
 
     Args:
@@ -75,13 +86,15 @@ def register_extension_routes(app: FastAPI, extension_app: ExtensionApp) -> None
         extension_app: Extension app that owns the registered routes.
     """
     for registered_route in extension_app.routes:
-        if isinstance(registered_route, EventRouteDefinition):
-            app.include_router(create_event_route(registered_route, extension_app))
-            continue
-        if isinstance(registered_route, APIRouteDefinition):
-            app.include_router(create_api_route(registered_route, extension_app))
-            continue
-        raise ConfigError("Only event and api routes are supported")
+        match registered_route:
+            case PlugRouteDefinition():
+                continue
+            case EventRouteDefinition():
+                app.include_router(create_event_route(registered_route, extension_app))
+            case APIRouteDefinition():
+                app.include_router(create_api_route(registered_route, extension_app))
+            case _:
+                raise ConfigError("Only event, api, and plug routes are supported")
 
 
 def _create_fastapi_app(extension_app: ExtensionApp) -> FastAPI:

--- a/mpt_extension_sdk/runtime/builders.py
+++ b/mpt_extension_sdk/runtime/builders.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass, field
+
+from mpt_extension_sdk.routing.models import BaseRouteDefinition, PlugRouteDefinition
+from mpt_extension_sdk.routing.plugs import Plug
+from mpt_extension_sdk.runtime.models import MetaPlug
+
+
+@dataclass(kw_only=True)
+class PlugMetadataBuilder:
+    """Build plug metadata from registered plug providers."""
+
+    _plug_ids: set[str] = field(default_factory=set, init=False, repr=False)
+    routes: list[BaseRouteDefinition]
+
+    def build(self) -> list[MetaPlug]:
+        """Build plug metadata."""
+        self._plug_ids.clear()
+        meta_plugs: list[MetaPlug] = []
+        for raw_plug in self._iter_plugs():
+            plug = self._validate_plug(raw_plug)
+            meta_plugs.append(self._create_meta_plug(plug))
+        return meta_plugs
+
+    def _create_meta_plug(self, plug: Plug) -> MetaPlug:
+        """Create a runtime metadata plug from a declared plug."""
+        return MetaPlug(
+            id=plug.id,
+            name=plug.name,
+            description=plug.description,
+            icon=plug.icon,
+            socket=plug.socket,
+            condition=plug.condition,
+            href=plug.href,
+        )
+
+    def _iter_plugs(self) -> list[object]:
+        """Return all plugs declared by registered plug providers."""
+        plugs: list[object] = []
+        for route in self.routes:
+            if isinstance(route, PlugRouteDefinition):
+                plugs.extend(route.callback())
+        return plugs
+
+    def _validate_plug(self, plug: object) -> Plug:
+        """Validate plug provider output."""
+        if not isinstance(plug, Plug):
+            raise TypeError("Plug providers must return Plug instances")
+        self._validate_unique_plug_id(plug)
+        return plug
+
+    def _validate_unique_plug_id(self, plug: Plug) -> None:
+        """Validate that a plug id has not already been declared."""
+        if plug.id in self._plug_ids:
+            raise ValueError(f"Plug id '{plug.id}' is already registered")
+        self._plug_ids.add(plug.id)

--- a/mpt_extension_sdk/runtime/models.py
+++ b/mpt_extension_sdk/runtime/models.py
@@ -19,6 +19,21 @@ class MetaEvent(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class MetaPlug(BaseModel):
+    """MetaPlug model for loading metadata."""
+
+    # Keep the order of fields in the model consistent with the order in the metadata file
+    id: str = Field(min_length=1)
+    name: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    icon: str | None = Field(default=None, min_length=1)
+    socket: str = Field(min_length=1)
+    condition: str | None = Field(default=None, min_length=1)
+    href: str = Field(min_length=1)
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class MetaConfig(BaseModel):
     """MetaConfig model for loading metadata."""
 
@@ -27,6 +42,7 @@ class MetaConfig(BaseModel):
     version: str = Field(default="1.0.0", min_length=1)
 
     events: list[MetaEvent]
+    plugs: list[MetaPlug] | None = None
 
     model_config = ConfigDict(extra="forbid")
 

--- a/tests/api/builders/test_api.py
+++ b/tests/api/builders/test_api.py
@@ -1,3 +1,4 @@
+import asyncio
 from contextlib import contextmanager
 from http import HTTPStatus
 
@@ -11,9 +12,7 @@ from mpt_extension_sdk.api.auth import AccountType
 from mpt_extension_sdk.api.builders.api import create_api_route
 from mpt_extension_sdk.api.builders.arguments import APIHandlerArgumentsBuilder
 from mpt_extension_sdk.extension_app import ExtensionApp
-from mpt_extension_sdk.routing import APIRouter
-from mpt_extension_sdk.routing.enums import HTTPMethod, RouteType
-from mpt_extension_sdk.routing.models import APIRouteDefinition
+from mpt_extension_sdk.routing import APIRouteDefinition, APIRouter, HTTPMethod, RouteType
 from mpt_extension_sdk.runtime import app as runtime_app
 from mpt_extension_sdk.schemas import BaseSchema
 from mpt_extension_sdk.services.mpt_api_service import MPTAPIService
@@ -180,7 +179,8 @@ def ok_response_factory():
 
 @pytest.fixture
 def async_ok_handler(ok_response_factory):
-    async def wrapper(ctx):  # noqa: RUF029
+    async def wrapper(ctx):
+        await asyncio.sleep(0)
         return ok_response_factory(payload={"ok": bool(ctx)})
 
     return wrapper

--- a/tests/api/test_pagination.py
+++ b/tests/api/test_pagination.py
@@ -47,23 +47,23 @@ def test_pagination_validates_page(query):
 
 
 def test_pagination_links_first_page():
-    links = PaginationLinksBuilder.build(
+    result = PaginationLinksBuilder.build(
         "https://example.com/orders", PaginatedResult(payload=[], total=0, page=1, page_size=10)
-    )  # act
+    )
 
-    assert links["prev"] is None
-    assert links["next"] is None
-    assert links["last"] == "https://example.com/orders?page=1&page_size=10"
+    assert result["prev"] is None
+    assert result["next"] is None
+    assert result["last"] == "https://example.com/orders?page=1&page_size=10"
 
 
 def test_pagination_links_replace_page_params():
-    links = PaginationLinksBuilder.build(
+    result = PaginationLinksBuilder.build(
         "https://example.com/orders?foo=bar&page=9&page_size=1",
         PaginatedResult(payload=[], total=TOTAL_ITEMS, page=2, page_size=10),
-    )  # act
+    )
 
-    assert links["self"] == "https://example.com/orders?foo=bar&page=2&page_size=10"
-    assert links["first"] == "https://example.com/orders?foo=bar&page=1&page_size=10"
-    assert links["prev"] == "https://example.com/orders?foo=bar&page=1&page_size=10"
-    assert links["next"] == "https://example.com/orders?foo=bar&page=3&page_size=10"
-    assert links["last"] == "https://example.com/orders?foo=bar&page=3&page_size=10"
+    assert result["self"] == "https://example.com/orders?foo=bar&page=2&page_size=10"
+    assert result["first"] == "https://example.com/orders?foo=bar&page=1&page_size=10"
+    assert result["prev"] == "https://example.com/orders?foo=bar&page=1&page_size=10"
+    assert result["next"] == "https://example.com/orders?foo=bar&page=3&page_size=10"
+    assert result["last"] == "https://example.com/orders?foo=bar&page=3&page_size=10"

--- a/tests/api/test_responses.py
+++ b/tests/api/test_responses.py
@@ -55,7 +55,7 @@ def test_api_response_ok_serializes_body():
         links={"self": "https://example.com/orders/ORD-1"},
     )
 
-    result = response.to_http_response()  # act
+    result = response.to_http_response()
 
     assert result.status_code == HTTPStatus.OK
     assert json.loads(result.body) == {
@@ -97,7 +97,7 @@ def test_api_response_paginated_adds_links():
 
     result = APIResponse.paginated(paginated_result).to_http_response(
         request_url="https://example.com/orders?page=2&page_size=5"
-    )  # act
+    )
 
     payload = json.loads(result.body)
     assert result.status_code == HTTPStatus.OK

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -3,9 +3,9 @@ from dataclasses import replace
 import pytest
 from typer.testing import CliRunner
 
-from mpt_extension_sdk.cli.main import app
+from mpt_extension_sdk.cli.main import app, validate_plug_static_assets
 from mpt_extension_sdk.errors.runtime import ConfigError
-from mpt_extension_sdk.runtime.models import MetaConfig, MetaEvent
+from mpt_extension_sdk.runtime.models import MetaConfig, MetaEvent, MetaPlug
 
 
 @pytest.fixture
@@ -24,6 +24,25 @@ def meta():
                 condition=None,
                 path="/events/orders/purchase",
                 task=False,
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def plug_meta():
+    return MetaConfig(
+        version="1.0.0",
+        openapi="/bypass/openapi.json",
+        events=[],
+        plugs=[
+            MetaPlug(
+                id="adobe",
+                name="Adobe",
+                description="Adobe widget",
+                icon="/static/assets/adobe.png",
+                socket="commerce.agreements.agreement",
+                href="/static/main-menu.js",
             )
         ],
     )
@@ -83,6 +102,63 @@ def test_validate_succeeds_when_meta_matches(
 
     assert result.exit_code == 0
     assert "Metadata is valid" in result.stdout
+
+
+def test_validate_checks_plug_static_assets(
+    runtime_settings_factory, cli_runner, mocker, monkeypatch, plug_meta, tmp_path
+):
+    static_dir = tmp_path / "static"
+    (static_dir / "assets").mkdir(parents=True)
+    (static_dir / "assets" / "adobe.png").write_text("icon", encoding="utf-8")
+    (static_dir / "main-menu.js").write_text("plug", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    settings = runtime_settings_factory(
+        meta_config=plug_meta, meta_file_path=tmp_path / "meta.yaml"
+    )
+    mocker.patch(
+        "mpt_extension_sdk.cli.main.RuntimeSettings.load", autospec=True, return_value=settings
+    )
+    mocker.patch(
+        "mpt_extension_sdk.cli.main.MetaConfig.from_file", autospec=True, return_value=plug_meta
+    )
+
+    result = cli_runner.invoke(app, ["meta", "validate"])
+
+    assert result.exit_code == 0
+
+
+def test_validate_writes_missing_plug_asset(
+    runtime_settings_factory, cli_runner, mocker, monkeypatch, plug_meta, tmp_path
+):
+    (tmp_path / "static").mkdir()
+    monkeypatch.chdir(tmp_path)
+    settings = runtime_settings_factory(
+        meta_config=plug_meta, meta_file_path=tmp_path / "meta.yaml"
+    )
+    mocker.patch(
+        "mpt_extension_sdk.cli.main.RuntimeSettings.load", autospec=True, return_value=settings
+    )
+
+    result = cli_runner.invoke(app, ["meta", "validate"])
+
+    assert result.exit_code == 1
+    assert "Invalid plug static assets" in result.stderr
+    assert "Plug asset file was not found" in result.stderr
+    assert (tmp_path / "meta.generated.yaml").exists()
+
+
+def test_validate_plug_assets_rejects_unprefixed(plug_meta, tmp_path):
+    plug_meta.plugs[0].href = "main-menu.js"
+
+    with pytest.raises(ConfigError, match="must start with /static/"):
+        validate_plug_static_assets(plug_meta, tmp_path / "static")
+
+
+def test_validate_plug_assets_rejects_traversal(plug_meta, tmp_path):
+    plug_meta.plugs[0].href = "/static/../secret.js"
+
+    with pytest.raises(ConfigError, match="escapes static folder"):
+        validate_plug_static_assets(plug_meta, tmp_path / "static")
 
 
 def test_validate_generates_missing_meta_file(

--- a/tests/routing/routers/test_plug.py
+++ b/tests/routing/routers/test_plug.py
@@ -1,14 +1,71 @@
-from mpt_extension_sdk.routing import PlugRouter, RouteType
+from collections.abc import Callable
+
+import pytest
+
+from mpt_extension_sdk.routing import Plug, PlugRouter, RouteType
 
 
-def test_plug_router_registers_handler(route_handler):
+def test_plug_normalizes_static_asset_paths():
+    result = Plug(
+        id="adobe",
+        name="Adobe",
+        description="Adobe widget",
+        icon="assets/adobe.png",
+        socket="commerce.agreements.agreement",
+        href="/static/main-menu.js",
+    )
+
+    assert result.icon == "/static/assets/adobe.png"
+    assert result.href == "/static/main-menu.js"
+
+
+def test_plug_rejects_path_traversal():
+    with pytest.raises(
+        ValueError, match="Plug static asset path must stay under the static folder"
+    ):
+        Plug(
+            id="adobe",
+            name="Adobe",
+            description="Adobe widget",
+            socket="commerce.agreements.agreement",
+            href="../main-menu.js",
+        )
+
+
+@pytest.mark.parametrize("href", ["/static", "/static/"])
+def test_plug_rejects_static_root_path(href):
+    with pytest.raises(ValueError, match="Plug static asset path must include a file"):
+        Plug(
+            id="adobe",
+            name="Adobe",
+            description="Adobe widget",
+            socket="commerce.agreements.agreement",
+            href=href,
+        )
+
+
+def test_plug_router_registers_provider(mocker):
     router = PlugRouter(prefix="/plug")
+    plug_provider = mocker.Mock(
+        return_value=Plug(
+            id="adobe",
+            name="Adobe",
+            description="Adobe widget",
+            socket="commerce.agreements.agreement",
+            href="main-menu.js",
+        ),
+        spec=Callable,
+        __name__="plug_provider",
+    )
 
-    result = router.plug(path="assets", name="assets")(route_handler)
+    result = router.register()(plug_provider)
 
-    assert result is route_handler
     assert len(router.routes) == 1
+    assert result is plug_provider
     route = router.routes[0]
-    assert route.path == "/plug/assets"
-    assert route.name == "assets"
-    assert route.route_type == RouteType.PLUG
+    assert (route.path, route.name, route.route_type) == (
+        "/plug/plug_provider",
+        "plug_provider",
+        RouteType.PLUG,
+    )
+    assert route.callback() == plug_provider()

--- a/tests/runtime/test_app.py
+++ b/tests/runtime/test_app.py
@@ -4,11 +4,24 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from mpt_extension_sdk import APIRouter, EventRouter, Plug, PlugRouter
 from mpt_extension_sdk.api import APIResponse
 from mpt_extension_sdk.errors.runtime import ConfigError
 from mpt_extension_sdk.extension_app import ExtensionApp
-from mpt_extension_sdk.routing import APIRouter, EventRouter, RouteType, ScheduleRouteDefinition
+from mpt_extension_sdk.routing import RouteType, ScheduleRouteDefinition
 from mpt_extension_sdk.runtime import app as runtime_app
+
+
+def runtime_plug_provider():
+    return [
+        Plug(
+            id="adobe",
+            name="Adobe",
+            description="Adobe widget",
+            socket="commerce.agreements.agreement",
+            href="main-menu.js",
+        )
+    ]
 
 
 @pytest.fixture
@@ -62,6 +75,15 @@ def api_extension_app():
         return APIResponse.ok(payload={"ok": bool(ctx)})
 
     extension_app.include_router(api_router)
+    return extension_app
+
+
+@pytest.fixture
+def plug_extension_app():
+    extension_app = ExtensionApp(prefix="/api/v1")
+    plug_router = PlugRouter()
+    plug_router.register()(runtime_plug_provider)
+    extension_app.include_router(plug_router)
     return extension_app
 
 
@@ -130,6 +152,12 @@ def test_create_runtime_app_registers_ext_routes(runtime_settings, runtime_app_p
     assert "/api/v1/events/orders/purchase" in {route.path for route in result.routes}
 
 
+def test_create_runtime_app_mounts_static(runtime_settings, runtime_app_patches):
+    result = runtime_app.create_runtime_app(runtime_settings)
+
+    assert "/static" in {route.path for route in result.routes}
+
+
 def test_register_ext_routes(dummy_handler):
     app = FastAPI()
     extension_app = ExtensionApp(prefix="/api/v1")
@@ -154,6 +182,14 @@ def test_register_api_ext_routes(api_extension_app):
     assert "GET" in api_route.methods
 
 
+def test_register_ext_routes_ignores_plugs(plug_extension_app):
+    app = FastAPI()
+
+    runtime_app.register_extension_routes(app, plug_extension_app)  # act
+
+    assert all(route.path != "/api/v1/plug_provider" for route in app.routes)
+
+
 def test_register_not_supported_ext_routes(dummy_handler):
     app = FastAPI()
     extension_app = ExtensionApp(prefix="/api/v1")
@@ -163,7 +199,7 @@ def test_register_not_supported_ext_routes(dummy_handler):
         )
     )
 
-    with pytest.raises(ConfigError, match="Only event and api routes are supported"):
+    with pytest.raises(ConfigError, match="Only event, api, and plug routes are supported"):
         runtime_app.register_extension_routes(app, extension_app)
 
 

--- a/tests/runtime/test_builders.py
+++ b/tests/runtime/test_builders.py
@@ -1,0 +1,31 @@
+from mpt_extension_sdk.routing import Plug, PlugRouteDefinition, RouteType
+from mpt_extension_sdk.runtime.builders import PlugMetadataBuilder
+
+
+def test_plug_metadata_builder_reuse(mocker):
+    plug_provider = mocker.Mock(
+        return_value=[
+            Plug(
+                id="adobe",
+                name="Adobe",
+                description="Adobe widget",
+                socket="commerce.agreements.agreement",
+                href="main-menu.js",
+            )
+        ]
+    )
+    plug_metadata_builder = PlugMetadataBuilder(
+        routes=[
+            PlugRouteDefinition(
+                name="plug-provider",
+                path="/plug-provider",
+                route_type=RouteType.PLUG,
+                callback=plug_provider,
+            )
+        ]
+    )
+    first_result = plug_metadata_builder.build()
+
+    result = plug_metadata_builder.build()  # act
+
+    assert first_result == result

--- a/tests/runtime/test_models.py
+++ b/tests/runtime/test_models.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 
 from mpt_extension_sdk.errors.runtime import ConfigError
-from mpt_extension_sdk.runtime.models import MetaConfig
+from mpt_extension_sdk.runtime.models import MetaConfig, MetaPlug
 
 
 def test_meta_config_from_file_reads_yaml(meta_config, tmp_path):
@@ -53,3 +53,41 @@ def test_meta_config_to_file_writes_yaml(meta_config, tmp_path):
         sort_keys=False,
         allow_unicode=False,
     )
+
+
+def test_meta_config_supports_plugs(tmp_path):
+    metadata_path = tmp_path / "meta.yaml"
+    metadata_path.write_text(
+        yaml.safe_dump(
+            {
+                "openapi": "/bypass/openapi.json",
+                "version": "1.0.0",
+                "events": [],
+                "plugs": [
+                    {
+                        "id": "adobe",
+                        "name": "Adobe",
+                        "description": "Adobe widget",
+                        "icon": "/static/adobe.png",
+                        "socket": "commerce.agreements.agreement",
+                        "href": "/static/main-menu.js",
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = MetaConfig.from_file(metadata_path)
+
+    assert result.plugs == [
+        MetaPlug(
+            id="adobe",
+            name="Adobe",
+            description="Adobe widget",
+            icon="/static/adobe.png",
+            socket="commerce.agreements.agreement",
+            href="/static/main-menu.js",
+        )
+    ]

--- a/tests/test_extension_app.py
+++ b/tests/test_extension_app.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import pytest
@@ -9,9 +10,15 @@ from mpt_extension_sdk.pipeline.context.event import (
     EventMetadata,
 )
 from mpt_extension_sdk.pipeline.context.order import OrderContext
-from mpt_extension_sdk.routing import APIRouter, EventRouter
-from mpt_extension_sdk.routing.enums import EventDeliveryMode, RouteType
-from mpt_extension_sdk.routing.models import EventRouteDefinition
+from mpt_extension_sdk.routing import (
+    APIRouter,
+    EventDeliveryMode,
+    EventRouteDefinition,
+    EventRouter,
+    Plug,
+    PlugRouter,
+    RouteType,
+)
 from mpt_extension_sdk.runtime.models import MetaConfig
 from mpt_extension_sdk.services.mpt_api_service import MPTAPIService
 from mpt_extension_sdk.settings.extension import BaseExtensionSettings
@@ -108,9 +115,92 @@ def test_meta_config_ignores_non_event_routes(dummy_handler):
 
     assert isinstance(result, MetaConfig)
     assert len(result.events) == 1
-    assert result.events[0].event == "OrderChanged"
-    assert result.events[0].path == "/api/v1/events/orders/change"
-    assert result.events[0].task is True
+    assert result.events[0].model_dump() == {
+        "event": "OrderChanged",
+        "condition": None,
+        "path": "/api/v1/events/orders/change",
+        "task": True,
+    }
+    assert result.plugs is None
+
+
+def test_meta_config_includes_plugs(mocker):
+    plug_router = PlugRouter()
+    app = ExtensionApp()
+    plug_router.register()(
+        mocker.MagicMock(
+            return_value=[
+                Plug(
+                    id="adobe",
+                    name="Adobe",
+                    description="Adobe widget",
+                    icon="adobe.png",
+                    socket="commerce.agreements.agreement",
+                    condition="eq(product.id,'PRD-1234-5677')",
+                    href="main-menu.js",
+                )
+            ],
+            spec=Callable,
+            __name__="plug_provider",
+        )
+    )
+    app.include_router(plug_router)
+
+    result = app.to_meta_config()
+
+    assert result.plugs is not None
+    assert result.plugs[0].model_dump(exclude_none=True) == {
+        "id": "adobe",
+        "name": "Adobe",
+        "description": "Adobe widget",
+        "icon": "/static/adobe.png",
+        "socket": "commerce.agreements.agreement",
+        "condition": "eq(product.id,'PRD-1234-5677')",
+        "href": "/static/main-menu.js",
+    }
+
+
+def test_meta_config_rejects_duplicate_plug_ids(mocker):
+    plug_router = PlugRouter()
+    app = ExtensionApp()
+    plug_router.register()(
+        mocker.MagicMock(
+            return_value=[
+                Plug(
+                    id="adobe",
+                    name="Adobe",
+                    description="Adobe widget",
+                    socket="commerce.agreements.agreement",
+                    href="main-menu.js",
+                ),
+                Plug(
+                    id="adobe",
+                    name="Adobe Copy",
+                    description="Adobe widget copy",
+                    socket="commerce.agreements.agreement",
+                    href="copy.js",
+                ),
+            ],
+            spec=Callable,
+            __name__="plug_provider",
+        )
+    )
+    app.include_router(plug_router)
+
+    with pytest.raises(ValueError, match="Plug id 'adobe' is already registered"):
+        app.to_meta_config()
+
+
+def test_meta_config_rejects_invalid_plug(mocker):
+    plug_router = PlugRouter()
+    app = ExtensionApp()
+    plug_router.register()(
+        mocker.MagicMock(return_value=["not-a-plug"], spec=Callable, __name__="not-a-plug")
+    )
+    app.include_router(plug_router)
+
+    with pytest.raises(TypeError, match="Plug providers must return Plug instances"):
+        app.to_meta_config()
 
 
 def test_ext_app_rejects_api_event_path_collision(dummy_handler):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20734](https://softwareone.atlassian.net/browse/MPT-20734)

- Add Plug dataclass to model extension UI plug metadata with automatic static asset path normalization (normalizes href and optional icon under /static/)
- Introduce PlugRouter.register() for provider-based plug registration, replacing the previous decorator-based plug()
- Add PlugMetadataBuilder to build MetaPlug entries from registered plug providers and enforce unique plug IDs
- Extend MetaConfig with optional plugs field so plug definitions are included in generated metadata
- Mount /static on the runtime FastAPI app to expose plug static assets; runtime skips registering plug routes
- Add validate_plug_static_assets() in CLI and call it from mpt-ext meta validate; validation checks /static/ prefix, prevents path traversal, verifies files exist, and causes meta.generated.yaml to be written on failure
- Export Plug, PlugRouteCallback, and STATIC_PATH_PREFIX from mpt_extension_sdk.routing
- Update docs to clarify: plug routes are declarative and emitted into metadata; event/API routes are mounted by the runtime; schedule routes are SDK-only and not mounted/emitted
- Add tests covering plug dataclass normalization/validation, router registration, CLI validation behavior, metadata generation, and runtime mounting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/mpt-extension-sdk/pull/186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20734]: https://softwareone.atlassian.net/browse/MPT-20734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ