### PR TITLE
MPT-20733 add trace span decorator

### DIFF
--- a/mpt_extension_sdk/observability/__init__.py
+++ b/mpt_extension_sdk/observability/__init__.py
@@ -1,0 +1,5 @@
+from mpt_extension_sdk.observability.decorators import trace_span
+
+__all__ = [  # noqa: WPS410
+    "trace_span",
+]

--- a/mpt_extension_sdk/observability/decorators.py
+++ b/mpt_extension_sdk/observability/decorators.py
@@ -1,9 +1,13 @@
+import logging
 from collections.abc import Awaitable, Callable
 from functools import wraps
-from typing import TYPE_CHECKING, Concatenate, cast
+from inspect import iscoroutinefunction
+from typing import TYPE_CHECKING, Any, Concatenate, cast
 
 from mpt_extension_sdk.observability.tracing import (
     TRACER,
+    Attributes,
+    AttributeValue,
     get_business_attributes,
     set_attributes,
 )
@@ -22,6 +26,46 @@ type StepCallable[
     ReturnT,
     **ParamT,
 ] = Callable[Concatenate[PipelineT, StepT, CtxT, ParamT], Awaitable[ReturnT]]
+type SpanAttributeValue = AttributeValue | Callable[..., AttributeValue | None] | None
+type SpanAttributes = dict[str, SpanAttributeValue]
+type SpanArgs = tuple[Any, ...]
+type SpanKwargs = dict[str, Any]
+
+logger = logging.getLogger(__name__)
+SPAN_ATTRIBUTE_RESOLUTION_ERRORS: tuple[type[Exception], ...] = (
+    AttributeError,
+    IndexError,
+    KeyError,
+    TypeError,
+    ValueError,
+)
+
+
+def trace_span(
+    name: str, attributes: SpanAttributes | None = None
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Start a child span around extension-defined business code."""
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        if iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: WPS430
+                with TRACER.start_as_current_span(name) as span:
+                    set_attributes(span, _resolve_span_attributes(attributes, args, kwargs))
+                    return await func(*args, **kwargs)
+
+            return async_wrapper
+
+        @wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: WPS430
+            with TRACER.start_as_current_span(name) as span:
+                set_attributes(span, _resolve_span_attributes(attributes, args, kwargs))
+                return func(*args, **kwargs)
+
+        return sync_wrapper
+
+    return decorator
 
 
 def start_pipeline_span[PipelineT: "BasePipeline", CtxT: "EventBaseContext", ReturnT, **ParamT](
@@ -76,3 +120,26 @@ def start_step_span[
             return await func(self, step, ctx, *args, **kwargs)
 
     return cast(StepCallable[PipelineT, StepT, CtxT, ReturnT, ParamT], wrapper)
+
+
+def _resolve_span_attributes(
+    attributes: SpanAttributes | None, args: SpanArgs, kwargs: SpanKwargs
+) -> Attributes:
+    """Resolve static or callable span attributes from decorated call arguments."""
+    if not attributes:
+        return {}
+
+    resolved_attributes: Attributes = {}
+    for key, attribute_source in attributes.items():
+        try:
+            resolved_value = (
+                attribute_source(*args, **kwargs)
+                if callable(attribute_source)
+                else attribute_source
+            )
+        except SPAN_ATTRIBUTE_RESOLUTION_ERRORS:
+            logger.debug("Skipping trace span attribute %s", key, exc_info=True)
+            continue
+        if isinstance(resolved_value, bool | str | int | float):
+            resolved_attributes[key] = resolved_value
+    return resolved_attributes

--- a/tests/observability/test_tracing.py
+++ b/tests/observability/test_tracing.py
@@ -1,3 +1,5 @@
+import asyncio
+from operator import itemgetter
 from typing import NamedTuple
 
 import pytest
@@ -6,9 +8,40 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from mpt_extension_sdk.observability import tracing
+from mpt_extension_sdk.observability import decorators, trace_span, tracing
 
 PATH = "/api/v2/events/orders/change"
+
+
+@trace_span(
+    "adobe.sync_agreement",
+    attributes={
+        "agreement.id": itemgetter("id"),
+        "sync.retry": 1,
+        "sync.enabled": True,
+        "sync.ignored": None,
+    },
+)
+async def trace_sample_async(agreement):
+    await asyncio.sleep(0)
+    return agreement["id"]
+
+
+@trace_span("adobe.build_payload")
+def trace_sample_sync():
+    return {"ok": True}
+
+
+@trace_span(
+    "adobe.sync_with_missing_attr",
+    attributes={
+        "agreement.id": itemgetter("id"),
+        "agreement.missing": itemgetter("missing"),
+    },
+)
+async def trace_sample_missing_attr(agreement):
+    await asyncio.sleep(0)
+    return agreement["id"]
 
 
 class FakeSpanRunResult(NamedTuple):
@@ -72,6 +105,55 @@ def test_event_span_sets_attributes(event_factory, event_span_runner):
     assert result.related_span.attributes["mpt.event.id"] == "EVT-1111-1112"
     assert result.related_span.attributes["mpt.event.type"] == "OrderPurchased"
     assert result.related_span.attributes["order.id"] == "ORD-1111-1112"
+
+
+def test_trace_span_wraps_async_attrs(mocker, span_exporter):
+    exporter, tracer = span_exporter
+    mocker.patch.object(decorators, "TRACER", tracer)
+
+    result = asyncio.run(trace_sample_async({"id": "AGR-1"}))
+
+    span = next(
+        finished_span
+        for finished_span in exporter.get_finished_spans()
+        if finished_span.name == "adobe.sync_agreement"
+    )
+    assert result == "AGR-1"
+    assert span.attributes["agreement.id"] == "AGR-1"
+    assert span.attributes["sync.retry"] == 1
+    assert span.attributes["sync.enabled"] is True
+    assert "sync.ignored" not in span.attributes
+
+
+def test_trace_span_wraps_sync_function(mocker, span_exporter):
+    exporter, tracer = span_exporter
+    mocker.patch.object(decorators, "TRACER", tracer)
+
+    result = trace_sample_sync()
+
+    span = next(
+        finished_span
+        for finished_span in exporter.get_finished_spans()
+        if finished_span.name == "adobe.build_payload"
+    )
+    assert result == {"ok": True}
+    assert span.name == "adobe.build_payload"
+
+
+def test_trace_span_omits_failing_callable_attr(mocker, span_exporter):
+    exporter, tracer = span_exporter
+    mocker.patch.object(decorators, "TRACER", tracer)
+
+    result = asyncio.run(trace_sample_missing_attr({"id": "AGR-2"}))
+
+    span = next(
+        finished_span
+        for finished_span in exporter.get_finished_spans()
+        if finished_span.name == "adobe.sync_with_missing_attr"
+    )
+    assert result == "AGR-2"
+    assert span.attributes["agreement.id"] == "AGR-2"
+    assert "agreement.missing" not in span.attributes
 
 
 def test_event_span_sets_agreement_attributes(event_factory, event_span_runner):


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

- Add the public `trace_span` observability decorator for extension-defined business operations.
- Re-export `trace_span` from `mpt_extension_sdk.observability` so extensions can import it directly.
- Support synchronous and asynchronous decorated functions.
- Support span attributes defined as static values or callables evaluated from decorated function arguments.
- Filter unsupported or `None` attribute values before setting OpenTelemetry span attributes.
- Add tests covering async span creation, sync span creation, callable attribute resolution, and attribute filtering.

## Testing

- `make check`
- `make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-20733](https://softwareone.atlassian.net/browse/MPT-20733)

- Add public trace_span observability decorator (mpt_extension_sdk.observability.decorators.trace_span) and re-export it from mpt_extension_sdk.observability; restrict module exports via __all__ = ["trace_span"]
- Support decorating both synchronous and asynchronous callables
- Allow span attributes to be static values or callables evaluated against the decorated function's args/kwargs
- Resolve and filter attributes via helper _resolve_span_attributes; omit None and unsupported types before setting OpenTelemetry span attributes
- Add span-related type aliases: SpanAttributeValue, SpanAttributes, SpanArgs, SpanKwargs
- Add tests covering async span creation, sync span creation, callable attribute resolution, and attribute filtering
- Run tests with: make check, make test

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/mpt-extension-sdk/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[MPT-20733]: https://softwareone.atlassian.net/browse/MPT-20733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ