### PR TITLE
MPT-20733: Add pytest asyncio support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dev = [
     "mypy==2.1.*",
     "pre-commit==4.6.*",
     "pytest==9.0.*",
+    "pytest-asyncio==1.3.*",
     "pytest-cov==7.1.*",
     "pytest-deadfixtures==3.1.*",
     "pytest-mock==3.15.*",
@@ -61,6 +62,8 @@ testpaths = "tests"
 pythonpath = "."
 addopts = "--cov=mpt_extension_sdk --cov-report=term-missing --cov-report=xml --import-mode=importlib"
 log_cli = false
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
     "ignore:Support for class-based `config` is deprecated:DeprecationWarning",
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning",

--- a/tests/api/builders/test_event.py
+++ b/tests/api/builders/test_event.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import json
 from collections.abc import Callable
@@ -468,22 +467,22 @@ def test_get_tasks_service(mocker, runtime_settings):
     )
 
 
-def test_run_handler(mocker, fake_context, mock_callable):
+async def test_run_handler(mocker, fake_context, mock_callable):
     mock_callable = mocker.AsyncMock(spec=Callable, side_effect=mock_callable)
 
-    asyncio.run(event_builder.run_handler(mock_callable, "evt", fake_context))  # act
+    await event_builder.run_handler(mock_callable, "evt", fake_context)  # act
 
     mock_callable.assert_awaited_once_with("evt", fake_context)
 
 
-def test_run_handler_supports_sync_handler(fake_context, mock_callable):
-    asyncio.run(event_builder.run_handler(mock_callable, "evt", fake_context))  # act
+async def test_run_handler_supports_sync_handler(fake_context, mock_callable):
+    await event_builder.run_handler(mock_callable, "evt", fake_context)  # act
 
     mock_callable.assert_called_once_with("evt", fake_context)
 
 
-def test_run_handler_propagates_async_exception(mocker, fake_context, mock_callable):
+async def test_run_handler_propagates_async_exception(mocker, fake_context, mock_callable):
     mock_callable = mocker.AsyncMock(spec=Callable, side_effect=ValueError("async boom"))
 
     with pytest.raises(ValueError, match="async boom"):
-        asyncio.run(event_builder.run_handler(mock_callable, "evt", fake_context))
+        await event_builder.run_handler(mock_callable, "evt", fake_context)

--- a/tests/observability/test_tracing.py
+++ b/tests/observability/test_tracing.py
@@ -107,11 +107,11 @@ def test_event_span_sets_attributes(event_factory, event_span_runner):
     assert result.related_span.attributes["order.id"] == "ORD-1111-1112"
 
 
-def test_trace_span_wraps_async_attrs(mocker, span_exporter):
+async def test_trace_span_wraps_async_attrs(mocker, span_exporter):
     exporter, tracer = span_exporter
     mocker.patch.object(decorators, "TRACER", tracer)
 
-    result = asyncio.run(trace_sample_async({"id": "AGR-1"}))
+    result = await trace_sample_async({"id": "AGR-1"})
 
     span = next(
         finished_span
@@ -140,11 +140,11 @@ def test_trace_span_wraps_sync_function(mocker, span_exporter):
     assert span.name == "adobe.build_payload"
 
 
-def test_trace_span_omits_failing_callable_attr(mocker, span_exporter):
+async def test_trace_span_omits_failing_callable_attr(mocker, span_exporter):
     exporter, tracer = span_exporter
     mocker.patch.object(decorators, "TRACER", tracer)
 
-    result = asyncio.run(trace_sample_missing_attr({"id": "AGR-2"}))
+    result = await trace_sample_missing_attr({"id": "AGR-2"})
 
     span = next(
         finished_span

--- a/tests/pipeline/context/test_agreement.py
+++ b/tests/pipeline/context/test_agreement.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from mpt_extension_sdk.pipeline.context.agreement import AgreementContext
 from mpt_extension_sdk.pipeline.context.event import EventMetadata
 from mpt_extension_sdk.services.mpt_api_service import MPTAPIService
@@ -29,7 +27,9 @@ def test_agreement_context_exposes_agreement_id(
     assert result == "AGR-99"
 
 
-def test_agreement_context_refreshes_agreement(mocker, logger, runtime_settings, agreement_factory):
+async def test_agreement_context_refreshes_agreement(
+    mocker, logger, runtime_settings, agreement_factory
+):
     service = mocker.AsyncMock(
         spec=MPTAPIService, agreements=mocker.AsyncMock(spec=AgreementService)
     )
@@ -48,7 +48,7 @@ def test_agreement_context_refreshes_agreement(mocker, logger, runtime_settings,
         agreement=agreement_factory("AGR-1"),
     )
 
-    asyncio.run(context.refresh_agreement())  # act
+    await context.refresh_agreement()  # act
 
     assert context.agreement.id == "AGR-2"
     service.agreements.get_by_id.assert_awaited_once_with("AGR-1")

--- a/tests/pipeline/context/test_order.py
+++ b/tests/pipeline/context/test_order.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from mpt_extension_sdk.pipeline.context.event import EventMetadata
 from mpt_extension_sdk.pipeline.context.order import OrderContext
 from mpt_extension_sdk.services.mpt_api_service import MPTAPIService
@@ -27,7 +25,7 @@ def test_order_context_exposes_order_id(mocker, logger, runtime_settings, order_
     assert result == "ORD-99"
 
 
-def test_order_context_refreshes_order(mocker, logger, runtime_settings, order_factory):
+async def test_order_context_refreshes_order(mocker, logger, runtime_settings, order_factory):
     service = mocker.AsyncMock(spec=MPTAPIService, orders=mocker.AsyncMock(spec=OrderService))
     service.orders.get_by_id = mocker.AsyncMock(return_value=order_factory("ORD-2"))
     context = OrderContext(
@@ -44,7 +42,7 @@ def test_order_context_refreshes_order(mocker, logger, runtime_settings, order_f
         order=order_factory("ORD-1"),
     )
 
-    asyncio.run(context.refresh_order())  # act
+    await context.refresh_order()  # act
 
     assert context.order.id == "ORD-2"
     service.orders.get_by_id.assert_awaited_once_with("ORD-1")

--- a/tests/pipeline/test_base.py
+++ b/tests/pipeline/test_base.py
@@ -1,4 +1,3 @@
-import asyncio
 from logging import Logger
 
 import pytest
@@ -74,11 +73,11 @@ def pipeline_ctx(mocker):
     return mocker.Mock(logger=logger)
 
 
-def test_execute_runs_all_steps(pipeline_ctx):
+async def test_execute_runs_all_steps(pipeline_ctx):
     steps = [FakePipelineStep("first"), FakePipelineStep("second")]
     pipeline = FakePipeline(steps)
 
-    asyncio.run(pipeline.execute(pipeline_ctx))  # act
+    await pipeline.execute(pipeline_ctx)  # act
 
     assert steps[0].run_calls == [pipeline_ctx]
     assert steps[1].run_calls == [pipeline_ctx]
@@ -86,57 +85,57 @@ def test_execute_runs_all_steps(pipeline_ctx):
     assert pipeline.succeeded[1] == (steps[1], pipeline_ctx)
 
 
-def test_execute_logs_pipeline_and_steps(pipeline_ctx):
+async def test_execute_logs_pipeline_and_steps(pipeline_ctx):
     steps = [FakePipelineStep("first"), FakePipelineStep("second")]
     pipeline = FakePipeline(steps)
 
-    asyncio.run(pipeline.execute(pipeline_ctx))  # act
+    await pipeline.execute(pipeline_ctx)  # act
 
     pipeline_ctx.logger.info.assert_any_call("Starting pipeline %s", pipeline.name)
     pipeline_ctx.logger.info.assert_any_call("Running step %s", "first")
     pipeline_ctx.logger.info.assert_any_call("Running step %s", "second")
 
 
-def test_execute_defers_pipeline(pipeline_ctx):
+async def test_execute_defers_pipeline(pipeline_ctx):
     error = DeferStepError("later", delay_seconds=42)
     step = FakePipelineStep("defer", side_effect=error)
     pipeline = FakePipeline([step])
 
     with pytest.raises(DeferError, match="later") as exc_info:
-        asyncio.run(pipeline.execute(pipeline_ctx))
+        await pipeline.execute(pipeline_ctx)
 
     assert exc_info.value.delay_seconds == 42
     assert pipeline.deferred == [step_event(step, pipeline_ctx, error)]
 
 
-def test_execute_skips_step(pipeline_ctx):
+async def test_execute_skips_step(pipeline_ctx):
     error = SkipStepError("skip")
     step = FakePipelineStep("skip", side_effect=error)
     pipeline = FakePipeline([step])
 
-    asyncio.run(pipeline.execute(pipeline_ctx))  # act
+    await pipeline.execute(pipeline_ctx)  # act
 
     assert pipeline.skipped == [step_event(step, pipeline_ctx, error)]
 
 
-def test_execute_stops_pipeline(pipeline_ctx):
+async def test_execute_stops_pipeline(pipeline_ctx):
     error = StopStepError("stop")
     step = FakePipelineStep("stop", side_effect=error)
     pipeline = FakePipeline([step])
 
     with pytest.raises(CancelError, match="stop"):
-        asyncio.run(pipeline.execute(pipeline_ctx))
+        await pipeline.execute(pipeline_ctx)
 
     assert pipeline.stopped == [step_event(step, pipeline_ctx, error)]
 
 
-def test_execute_fails_pipeline(pipeline_ctx):
+async def test_execute_fails_pipeline(pipeline_ctx):
     error = RuntimeError("boom")
     step = FakePipelineStep("fail", side_effect=error)
     pipeline = FakePipeline([step])
 
     with pytest.raises(RuntimeError, match="boom"):
-        asyncio.run(pipeline.execute(pipeline_ctx))
+        await pipeline.execute(pipeline_ctx)
 
     assert pipeline.failed == [step_event(step, pipeline_ctx, error)]
 
@@ -164,31 +163,31 @@ def test_execute_fails_pipeline(pipeline_ctx):
         ),
     ],
 )
-def test_default_error_callbacks_log(pipeline_ctx, method_name, step_name, error, message):
+async def test_default_error_callbacks_log(pipeline_ctx, method_name, step_name, error, message):
     pipeline = FakeLoggingPipeline([])
     step = FakePipelineStep(step_name)
     method = getattr(pipeline, method_name)
 
-    asyncio.run(method(step, pipeline_ctx, error))  # act
+    await method(step, pipeline_ctx, error)  # act
 
     pipeline_ctx.logger.info.assert_called_once_with(message, step_name, error)
 
 
-def test_default_succeeded_callback_logs(pipeline_ctx):
+async def test_default_succeeded_callback_logs(pipeline_ctx):
     pipeline = FakeLoggingPipeline([])
     step = FakePipelineStep("done")
 
-    asyncio.run(pipeline.on_step_succeeded(step, pipeline_ctx))  # act
+    await pipeline.on_step_succeeded(step, pipeline_ctx)  # act
 
     pipeline_ctx.logger.info.assert_called_once_with("Step %s completed", step.name)
 
 
-def test_default_failed_callback_logs_exception(pipeline_ctx):
+async def test_default_failed_callback_logs_exception(pipeline_ctx):
     pipeline = FakeLoggingPipeline([])
     step = FakePipelineStep("fail")
     error = RuntimeError("boom")
 
-    asyncio.run(pipeline.on_step_failed(step, pipeline_ctx, error))  # act
+    await pipeline.on_step_failed(step, pipeline_ctx, error)  # act
 
     pipeline_ctx.logger.error.assert_called_once_with(
         "Step %s - unhandled exception", step.name, exc_info=error

--- a/tests/pipeline/test_decorators.py
+++ b/tests/pipeline/test_decorators.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections.abc import Callable
 
 import pytest
@@ -24,7 +23,7 @@ class SampleStep(BaseStep):
         return ctx
 
 
-def test_refresh_order(mocker, logger, runtime_settings, order_factory):
+async def test_refresh_order(mocker, logger, runtime_settings, order_factory):
     context = OrderContext(
         logger=logger,
         meta=EventMetadata(
@@ -40,13 +39,13 @@ def test_refresh_order(mocker, logger, runtime_settings, order_factory):
     )
     context.refresh_order = mocker.AsyncMock(spec=Callable)
 
-    result = asyncio.run(SampleStep().decorated(context))
+    result = await SampleStep().decorated(context)
 
     assert result == context
     context.refresh_order.assert_awaited_once_with()
 
 
-def test_refresh_order_on_failure(mocker, logger, runtime_settings, order_factory):
+async def test_refresh_order_on_failure(mocker, logger, runtime_settings, order_factory):
     context = OrderContext(
         logger=logger,
         meta=EventMetadata(
@@ -63,6 +62,6 @@ def test_refresh_order_on_failure(mocker, logger, runtime_settings, order_factor
     context.refresh_order = mocker.AsyncMock(spec=Callable)
 
     with pytest.raises(RuntimeError, match="boom"):
-        asyncio.run(SampleStep().failing(context))
+        await SampleStep().failing(context)
 
     context.refresh_order.assert_not_awaited()

--- a/tests/pipeline/test_factory.py
+++ b/tests/pipeline/test_factory.py
@@ -1,4 +1,3 @@
-import asyncio
 from contextlib import contextmanager
 
 import pytest
@@ -29,7 +28,7 @@ def event_context_scope():
         task_id_ctx.reset(task_token)
 
 
-def test_build_context_returns_order_context(
+async def test_build_context_returns_order_context(
     mocker, logger, runtime_settings, event_factory, order_factory
 ):
     auth = mocker.Mock()
@@ -49,13 +48,11 @@ def test_build_context_returns_order_context(
     )
     FakeAuthAPIService.from_auth_context = mocker.AsyncMock(return_value=fake_service)
 
-    result = asyncio.run(
-        build_context(
-            event_factory("Order", "ORD-1"),
-            logger,
-            auth=auth,
-            mpt_api_service_type=FakeAuthAPIService,
-        )
+    result = await build_context(
+        event_factory("Order", "ORD-1"),
+        logger,
+        auth=auth,
+        mpt_api_service_type=FakeAuthAPIService,
     )
 
     assert isinstance(result, OrderContext)
@@ -64,7 +61,7 @@ def test_build_context_returns_order_context(
     assert result.meta.object_type == "Order"
 
 
-def test_build_context_returns_agreement_context(
+async def test_build_context_returns_agreement_context(
     mocker, logger, runtime_settings, event_factory, agreement_factory
 ):
     auth = mocker.Mock(spec=AuthContext)
@@ -86,20 +83,20 @@ def test_build_context_returns_agreement_context(
     fake_service.agreements.get_by_id = mocker.AsyncMock(return_value=agreement_factory("AGR-1"))
     FakeAuthAPIService.from_auth_context = mocker.AsyncMock(return_value=fake_service)
 
-    result = asyncio.run(
-        build_context(
-            event_factory("Agreement", "AGR-1"),
-            logger,
-            auth=auth,
-            mpt_api_service_type=FakeAuthAPIService,
-        )
+    result = await build_context(
+        event_factory("Agreement", "AGR-1"),
+        logger,
+        auth=auth,
+        mpt_api_service_type=FakeAuthAPIService,
     )
 
     assert isinstance(result, AgreementContext)
     assert result.meta.object_type == "Agreement"
 
 
-def test_build_ctx_rejects_unsupported_obj_type(mocker, logger, runtime_settings, event_factory):
+async def test_build_ctx_rejects_unsupported_obj_type(
+    mocker, logger, runtime_settings, event_factory
+):
     auth = mocker.Mock(spec=AuthContext)
     auth.extension_id = "EXT-1"
     mocker.patch(
@@ -116,17 +113,15 @@ def test_build_ctx_rejects_unsupported_obj_type(mocker, logger, runtime_settings
     FakeAuthAPIService.from_auth_context = mocker.AsyncMock(return_value=mocker.AsyncMock())
 
     with pytest.raises(RuntimeError, match="Unsupported context type: Subscription"):
-        asyncio.run(
-            build_context(
-                event_factory("Subscription", "SUB-1"),
-                logger,
-                auth=auth,
-                mpt_api_service_type=FakeAuthAPIService,
-            )
+        await build_context(
+            event_factory("Subscription", "SUB-1"),
+            logger,
+            auth=auth,
+            mpt_api_service_type=FakeAuthAPIService,
         )
 
 
-def test_build_context_carries_contextvars(
+async def test_build_context_carries_contextvars(
     mocker, logger, runtime_settings, event_factory, order_factory
 ):
     auth = mocker.Mock()
@@ -143,20 +138,18 @@ def test_build_context_carries_contextvars(
     )
 
     with event_context_scope():
-        result = asyncio.run(
-            build_context(
-                event_factory("Order", "ORD-1"),
-                logger,
-                auth=auth,
-                mpt_api_service_type=FakeAuthAPIService,
-            )
+        result = await build_context(
+            event_factory("Order", "ORD-1"),
+            logger,
+            auth=auth,
+            mpt_api_service_type=FakeAuthAPIService,
         )
 
         assert result.meta.correlation_id == "corr-1"
         assert result.meta.task_id == "task-ctx"
 
 
-def test_build_context_uses_auth_context(
+async def test_build_context_uses_auth_context(
     mocker, logger, runtime_settings, event_factory, order_factory
 ):
     auth = mocker.Mock(spec=AuthContext)
@@ -175,13 +168,11 @@ def test_build_context_uses_auth_context(
     )
     FakeAuthAPIService.from_auth_context = mocker.AsyncMock(return_value=service)
 
-    result = asyncio.run(
-        build_context(
-            event_factory("Order", "ORD-1"),
-            logger,
-            auth=auth,
-            mpt_api_service_type=FakeAuthAPIService,
-        )
+    result = await build_context(
+        event_factory("Order", "ORD-1"),
+        logger,
+        auth=auth,
+        mpt_api_service_type=FakeAuthAPIService,
     )
 
     assert result.auth is auth
@@ -191,7 +182,9 @@ def test_build_context_uses_auth_context(
     )
 
 
-def test_build_context_rejects_mismatched_ext_id(mocker, logger, runtime_settings, event_factory):
+async def test_build_context_rejects_mismatched_ext_id(
+    mocker, logger, runtime_settings, event_factory
+):
     auth = mocker.Mock(spec=AuthContext)
     auth.extension_id = "EXT-2"
     FakeAuthAPIService.from_auth_context = mocker.AsyncMock()
@@ -207,13 +200,11 @@ def test_build_context_rejects_mismatched_ext_id(mocker, logger, runtime_setting
     )
 
     with pytest.raises(AuthenticationError):
-        asyncio.run(
-            build_context(
-                event_factory("Order", "ORD-1"),
-                logger,
-                auth=auth,
-                mpt_api_service_type=FakeAuthAPIService,
-            )
+        await build_context(
+            event_factory("Order", "ORD-1"),
+            logger,
+            auth=auth,
+            mpt_api_service_type=FakeAuthAPIService,
         )
 
     FakeAuthAPIService.from_auth_context.assert_not_awaited()

--- a/tests/pipeline/test_step.py
+++ b/tests/pipeline/test_step.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 
 from mpt_extension_sdk.context import BaseContext
@@ -45,49 +43,49 @@ def test_step_name():
     assert result == "FakeStep"
 
 
-def test_run_calls_pre_process_post(context_mock):
+async def test_run_calls_pre_process_post(context_mock):
     step = FakeStep()
 
-    asyncio.run(step.run(context_mock))  # act
+    await step.run(context_mock)  # act
 
     assert step.calls == [("pre", context_mock), ("process", context_mock), ("post", context_mock)]
 
 
-def test_run_raises_process_error_after_post(context_mock):
+async def test_run_raises_process_error_after_post(context_mock):
     error = RuntimeError("process failed")
     step = FakeStep(process_error=error)
 
     with pytest.raises(RuntimeError, match="process failed"):
-        asyncio.run(step.run(context_mock))
+        await step.run(context_mock)
 
     assert step.calls == [("pre", context_mock), ("process", context_mock), ("post", context_mock)]
 
 
-def test_run_raises_post_error(context_mock):
+async def test_run_raises_post_error(context_mock):
     error = RuntimeError("post failed")
     step = FakeStep(post_error=error)
 
     with pytest.raises(RuntimeError, match="post failed"):
-        asyncio.run(step.run(context_mock))
+        await step.run(context_mock)
 
     assert step.calls == [("pre", context_mock), ("process", context_mock), ("post", context_mock)]
 
 
-def test_run_chains_post_error_from_process_error(context_mock):
+async def test_run_chains_post_error_from_process_error(context_mock):
     process_error = RuntimeError("process failed")
     post_error = RuntimeError("post failed")
     step = FakeStep(process_error=process_error, post_error=post_error)
 
     with pytest.raises(RuntimeError, match="post failed") as exc_info:
-        asyncio.run(step.run(context_mock))
+        await step.run(context_mock)
 
     assert exc_info.value.__cause__ is process_error
     assert step.calls == [("pre", context_mock), ("process", context_mock), ("post", context_mock)]
 
 
-def test_run_uses_default_pre_and_post_hooks(context_mock):
+async def test_run_uses_default_pre_and_post_hooks(context_mock):
     step = FakeMinimalStep()
 
-    asyncio.run(step.run(context_mock))  # act
+    await step.run(context_mock)  # act
 
     assert step.calls == [("process", context_mock)]

--- a/tests/services/mpt_api_service/test_account_scoped.py
+++ b/tests/services/mpt_api_service/test_account_scoped.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import datetime as dt
 import json
@@ -49,9 +48,9 @@ def build_token_provider(mocker, runtime_settings):  # noqa: WPS210
     return provider, service_type, installations
 
 
-def get_provider_tokens(provider):
+async def get_provider_tokens(provider):
     """Request the account token twice."""
-    return [asyncio.run(provider.get_token()), asyncio.run(provider.get_token())]
+    return [await provider.get_token(), await provider.get_token()]
 
 
 @pytest.fixture
@@ -61,7 +60,7 @@ def clear_account_token_cache():
     AccountTokenProvider.clear_cache()
 
 
-def test_create_token_query_params(mocker, async_mpt_client):
+async def test_create_token_query_params(mocker, async_mpt_client):
     installations = mocker.Mock()
     installations.path = "/public/v1/integration/installations/-/token"
     response = mocker.Mock()
@@ -70,7 +69,7 @@ def test_create_token_query_params(mocker, async_mpt_client):
     async_mpt_client.integration.installations.return_value = installations
     service = InstallationService(async_mpt_client)
 
-    result = asyncio.run(service.create_token("ACC-1"))
+    result = await service.create_token("ACC-1")
 
     assert result.token == build_token(4102444800)
     installations.http_client.request.assert_awaited_once_with(
@@ -80,10 +79,10 @@ def test_create_token_query_params(mocker, async_mpt_client):
     )
 
 
-def test_provider_caches_token(clear_account_token_cache, mocker, runtime_settings):
+async def test_provider_caches_token(clear_account_token_cache, mocker, runtime_settings):
     provider, service_type, installations = build_token_provider(mocker, runtime_settings)
 
-    token_results = get_provider_tokens(provider)  # act
+    token_results = await get_provider_tokens(provider)  # act
 
     assert token_results == ["account-token", "account-token"]
     service_type.from_config.assert_called_once_with(
@@ -105,7 +104,7 @@ def test_mpt_client_uses_refreshing_http_client(mocker):
     assert isinstance(result.http_client, AccountScopedAsyncHTTPClient)
 
 
-def test_http_client_refreshes_each_request(mocker):
+async def test_http_client_refreshes_each_request(mocker):
     token_provider = mocker.Mock()
     token_provider.get_token = mocker.AsyncMock(side_effect=["account-token-1", "account-token-2"])
     response = mocker.Mock()
@@ -117,8 +116,8 @@ def test_http_client_refreshes_each_request(mocker):
     )
 
     request_results = [
-        asyncio.run(client.request("get", "/orders/ORD-1", headers={"x-test": "1"})),
-        asyncio.run(client.request("get", "/orders/ORD-1", headers={"x-test": "1"})),
+        await client.request("get", "/orders/ORD-1", headers={"x-test": "1"}),
+        await client.request("get", "/orders/ORD-1", headers={"x-test": "1"}),
     ]  # act
 
     assert request_results == [response, response]

--- a/tests/services/mpt_api_service/test_agreement.py
+++ b/tests/services/mpt_api_service/test_agreement.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections.abc import Callable
 
 import pytest
@@ -17,7 +16,7 @@ def agreement_service_factory(mocker, async_mpt_client):
     return factory
 
 
-def test_get_by_id(mocker, agreement_service_factory):
+async def test_get_by_id(mocker, agreement_service_factory):
     api_agreement = mocker.Mock(spec=["to_dict"])
     service, agreements_client = agreement_service_factory()
     agreements_client.get = mocker.AsyncMock(spec=Callable, return_value=api_agreement)
@@ -27,7 +26,7 @@ def test_get_by_id(mocker, agreement_service_factory):
         return_value="agreement-model",
     )
 
-    result = asyncio.run(service.get_by_id("AGR-1"))
+    result = await service.get_by_id("AGR-1")
 
     assert result == "agreement-model"
     agreements_client.get.assert_awaited_once_with(
@@ -47,10 +46,10 @@ def test_get_by_id(mocker, agreement_service_factory):
     from_payload.assert_called_once_with(api_agreement)
 
 
-def test_update_calls_agreement_update(mocker, agreement_service_factory):
+async def test_update_calls_agreement_update(mocker, agreement_service_factory):
     service, agreement_client = agreement_service_factory()
     agreement_client.update = mocker.AsyncMock(spec=Callable)
 
-    asyncio.run(service.update("AGR-1", {"status": "processing"}))  # act
+    await service.update("AGR-1", {"status": "processing"})  # act
 
     agreement_client.update.assert_awaited_once_with("AGR-1", {"status": "processing"})

--- a/tests/services/mpt_api_service/test_api_service.py
+++ b/tests/services/mpt_api_service/test_api_service.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from mpt_api_client import AsyncMPTClient
 
 from mpt_extension_sdk.api.auth import AuthContext
@@ -38,7 +36,7 @@ def test_api_service_from_config(mocker):
     assert result.client is client
 
 
-def test_from_auth_context_uses_account_client(mocker, runtime_settings):  # noqa: WPS210
+async def test_from_auth_context_uses_account_client(mocker, runtime_settings):  # noqa: WPS210
     auth = mocker.Mock(spec=AuthContext)
     client = mocker.AsyncMock(spec=AsyncMPTClient)
     get_runtime_settings = mocker.patch(
@@ -57,7 +55,7 @@ def test_from_auth_context_uses_account_client(mocker, runtime_settings):  # noq
         return_value=client,
     )
 
-    result = asyncio.run(MPTAPIService.from_auth_context("https://api.example.com", auth))
+    result = await MPTAPIService.from_auth_context("https://api.example.com", auth)
 
     assert isinstance(result, MPTAPIService)
     assert result.client is client

--- a/tests/services/mpt_api_service/test_asset.py
+++ b/tests/services/mpt_api_service/test_asset.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections.abc import Callable
 
 import pytest
@@ -21,7 +20,7 @@ def asset_client_mock(mocker, async_mpt_client):
     return factory
 
 
-def test_create(mocker, asset_client_mock):
+async def test_create(mocker, asset_client_mock):
     api_asset = mocker.Mock(spec=["id"])
     service, asset_client, _ = asset_client_mock()
     asset_client.create = mocker.AsyncMock(spec=Callable, return_value=api_asset)
@@ -31,14 +30,14 @@ def test_create(mocker, asset_client_mock):
         return_value="asset-model",
     )
 
-    result = asyncio.run(service.create({"name": "AST-1"}))
+    result = await service.create({"name": "AST-1"})
 
     assert result == "asset-model"
     asset_client.create.assert_awaited_once_with({"name": "AST-1"})
     from_payload.assert_called_once_with(api_asset)
 
 
-def test_create_order_asset(mocker, asset_client_mock):
+async def test_create_order_asset(mocker, asset_client_mock):
     api_asset = mocker.Mock(spec=["id"])
     service, _, order_asset_client = asset_client_mock()
     order_asset_client.create = mocker.AsyncMock(spec=Callable, return_value=api_asset)
@@ -48,14 +47,14 @@ def test_create_order_asset(mocker, asset_client_mock):
         return_value="asset-model",
     )
 
-    result = asyncio.run(service.create_order_asset("ORD-1", {"name": "AST-1"}))
+    result = await service.create_order_asset("ORD-1", {"name": "AST-1"})
 
     assert result == "asset-model"
     order_asset_client.create.assert_awaited_once_with({"name": "AST-1"})
     from_payload.assert_called_once_with(api_asset)
 
 
-def test_update(mocker, asset_client_mock):
+async def test_update(mocker, asset_client_mock):
     api_asset = mocker.Mock(spec=["id"])
     service, asset_client, _ = asset_client_mock()
     asset_client.update = mocker.AsyncMock(spec=Callable, return_value=api_asset)
@@ -65,7 +64,7 @@ def test_update(mocker, asset_client_mock):
         return_value="asset-model",
     )
 
-    result = asyncio.run(service.update("AST-1", {"description": "fake"}))
+    result = await service.update("AST-1", {"description": "fake"})
 
     assert result == "asset-model"
     asset_client.update.assert_awaited_once_with("AST-1", {"description": "fake"})

--- a/tests/services/mpt_api_service/test_base.py
+++ b/tests/services/mpt_api_service/test_base.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from mpt_extension_sdk.models.base import BaseModel
 from mpt_extension_sdk.services.api_client_v2.mpt_api_client import AsyncMPTClient
 from mpt_extension_sdk.services.mpt_api_service.base import BaseService
@@ -27,7 +25,7 @@ class FakeCollection:
             yield element
 
 
-def test_get_all_collects_models(mocker):
+async def test_get_all_collects_models(mocker):
     collection = FakeCollection(["one", "two"])
     mocker.patch.object(
         FakeModel,
@@ -37,16 +35,16 @@ def test_get_all_collects_models(mocker):
     )
     service = FakeService(mocker.Mock(spec=AsyncMPTClient))
 
-    result = asyncio.run(service.get_all(collection))
+    result = await service.get_all(collection)
 
     assert result == [{"payload": "one"}, {"payload": "two"}]
 
 
-def test_get_all_passes_batch_size(mocker):
+async def test_get_all_passes_batch_size(mocker):
     collection = FakeCollection(["x"])
     mocker.patch.object(FakeModel, "from_payload", autospec=True, return_value={"payload": "x"})
     service = FakeService(mocker.Mock())
 
-    asyncio.run(service.get_all(collection, batch_size=50))  # act
+    await service.get_all(collection, batch_size=50)  # act
 
     assert collection.batch_sizes == [50]

--- a/tests/services/mpt_api_service/test_order.py
+++ b/tests/services/mpt_api_service/test_order.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections.abc import Callable
 
 import pytest
@@ -22,7 +21,7 @@ def order_service_factory(mocker):
     return factory
 
 
-def test_get_by_id(mocker, order_service_factory):
+async def test_get_by_id(mocker, order_service_factory):
     api_order = mocker.Mock(spec=["to_dict"])
     service, orders_client = order_service_factory()
     orders_client.get = mocker.AsyncMock(spec=Callable, return_value=api_order)
@@ -32,7 +31,7 @@ def test_get_by_id(mocker, order_service_factory):
         return_value="order-model",
     )
 
-    result = asyncio.run(service.get_by_id("ORD-1"))
+    result = await service.get_by_id("ORD-1")
 
     assert result == "order-model"
     orders_client.get.assert_awaited_once_with(
@@ -60,12 +59,12 @@ def test_get_by_id(mocker, order_service_factory):
     from_payload.assert_called_once_with(api_order)
 
 
-def test_complete_calls_orders_complete(mocker, order_service_factory):
+async def test_complete_calls_orders_complete(mocker, order_service_factory):
     service, orders_client = order_service_factory()
     orders_client.complete = mocker.AsyncMock(spec=Callable)
     template = {"id": "TPL-1"}
 
-    asyncio.run(service.complete("ORD-1", template, attributes={"status": "completed"}))  # act
+    await service.complete("ORD-1", template, attributes={"status": "completed"})  # act
 
     orders_client.complete.assert_awaited_once_with(
         "ORD-1",
@@ -73,34 +72,32 @@ def test_complete_calls_orders_complete(mocker, order_service_factory):
     )
 
 
-def test_update_calls_orders_update(mocker, order_service_factory):
+async def test_update_calls_orders_update(mocker, order_service_factory):
     service, orders_client = order_service_factory()
     orders_client.update = mocker.AsyncMock(spec=Callable)
 
-    asyncio.run(service.update("ORD-1", {"status": "processing"}))  # act
+    await service.update("ORD-1", {"status": "processing"})  # act
 
     orders_client.update.assert_awaited_once_with("ORD-1", {"status": "processing"})
 
 
-def test_query_calls_orders_query(mocker, order_service_factory):
+async def test_query_calls_orders_query(mocker, order_service_factory):
     service, orders_client = order_service_factory()
     orders_client.query = mocker.AsyncMock(spec=Callable)
 
-    asyncio.run(service.query("ORD-1", {"reason": "missing-data"}))  # act
+    await service.query("ORD-1", {"reason": "missing-data"})  # act
 
     orders_client.query.assert_awaited_once_with("ORD-1", {"reason": "missing-data"})
 
 
-def test_fail_calls_orders_fail(mocker, order_service_factory):
+async def test_fail_calls_orders_fail(mocker, order_service_factory):
     service, orders_client = order_service_factory()
     orders_client.fail = mocker.AsyncMock(spec=Callable)
 
-    asyncio.run(
-        service.fail(
-            "ORD-1",
-            {"message": "failed"},
-            attributes={"reason": "validation-error"},
-        )
+    await service.fail(
+        "ORD-1",
+        {"message": "failed"},
+        attributes={"reason": "validation-error"},
     )  # act
 
     orders_client.fail.assert_awaited_once_with(

--- a/tests/services/mpt_api_service/test_product.py
+++ b/tests/services/mpt_api_service/test_product.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 from mpt_api_client.resources import AsyncCatalog
 from mpt_api_client.resources.catalog.items import AsyncItemsService
@@ -20,18 +18,18 @@ def product_item_service_factory(mocker, async_mpt_client):
     return factory
 
 
-def test_get_items_returns_empty_without_ids(mocker, product_item_service_factory):
+async def test_get_items_returns_empty_without_ids(mocker, product_item_service_factory):
     service, items_client = product_item_service_factory()
     iterate_all = mocker.patch.object(service, "_iterate_all", autospec=True)
 
-    result = asyncio.run(service.get_product_one_time_items_by_ids("PROD-1", []))
+    result = await service.get_product_one_time_items_by_ids("PROD-1", [])
 
     assert result == []
     items_client.filter.assert_not_called()
     iterate_all.assert_not_called()
 
 
-def test_get_items_filters_and_collects(mocker, product_item_service_factory):
+async def test_get_items_filters_and_collects(mocker, product_item_service_factory):
     service, items_client = product_item_service_factory()
     filtered_collection = mocker.Mock(spec=["iterate"])
     items_client.filter.return_value = filtered_collection
@@ -39,7 +37,7 @@ def test_get_items_filters_and_collects(mocker, product_item_service_factory):
         service, "_iterate_all", autospec=True, return_value=["item-1", "item-2"]
     )
 
-    result = asyncio.run(service.get_product_one_time_items_by_ids("PROD-1", ["ITEM-1", "ITEM-2"]))
+    result = await service.get_product_one_time_items_by_ids("PROD-1", ["ITEM-1", "ITEM-2"])
 
     assert result == ["item-1", "item-2"]
     items_client.filter.assert_called_once_with(mocker.ANY)

--- a/tests/services/mpt_api_service/test_subscription.py
+++ b/tests/services/mpt_api_service/test_subscription.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections.abc import Callable
 
 import pytest
@@ -15,7 +14,7 @@ def subscription_client_mock(mocker, async_mpt_client):
     return factory
 
 
-def test_create(mocker, subscription_client_mock):
+async def test_create(mocker, subscription_client_mock):
     api_subscription = mocker.Mock()
     service, subscription_client = subscription_client_mock()
     subscription_client.create = mocker.AsyncMock(return_value=api_subscription)
@@ -25,14 +24,14 @@ def test_create(mocker, subscription_client_mock):
         return_value="subscription-model",
     )
 
-    result = asyncio.run(service.create({"name": "SUB-1"}))
+    result = await service.create({"name": "SUB-1"})
 
     assert result == "subscription-model"
     subscription_client.create.assert_awaited_once_with({"name": "SUB-1"})
     from_payload.assert_called_once_with(api_subscription)
 
 
-def test_get_by_id(mocker, subscription_client_mock):
+async def test_get_by_id(mocker, subscription_client_mock):
     api_subscription = mocker.Mock()
     service, subscription_client = subscription_client_mock()
     subscription_client.get = mocker.AsyncMock(return_value=api_subscription)
@@ -42,17 +41,17 @@ def test_get_by_id(mocker, subscription_client_mock):
         return_value="subscription-model",
     )
 
-    result = asyncio.run(service.get_by_id("SUB-1"))
+    result = await service.get_by_id("SUB-1")
 
     assert result == "subscription-model"
     subscription_client.get.assert_awaited_once_with("SUB-1")
     from_payload.assert_called_once_with(api_subscription)
 
 
-def test_update(mocker, subscription_client_mock):
+async def test_update(mocker, subscription_client_mock):
     service, subscription_client = subscription_client_mock()
     subscription_client.update = mocker.AsyncMock(spec=Callable)
 
-    asyncio.run(service.update("SUB-1", {"description": "fake"}))  # act
+    await service.update("SUB-1", {"description": "fake"})  # act
 
     subscription_client.update.assert_awaited_once_with("SUB-1", {"description": "fake"})

--- a/tests/services/mpt_api_service/test_task.py
+++ b/tests/services/mpt_api_service/test_task.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 
 from mpt_extension_sdk.services.api_client_v2.mpt_api_client import AsyncMPTClient
@@ -18,14 +16,14 @@ from mpt_extension_sdk.services.mpt_api_service.task import TaskService
         ("start", ("TASK-1",), "execute", ("TASK-1",)),
     ],
 )
-def test_task_service_actions(mocker, method_name, args, client_method, client_args):
+async def test_task_service_actions(mocker, method_name, args, client_method, client_args):
     tasks_client = mocker.AsyncMock(spec=AsyncTasksService)
     client = mocker.Mock(spec=AsyncMPTClient, system=mocker.Mock(spec=AsyncSystem))
     client.system.tasks = tasks_client
     service = TaskService(client)
     method = getattr(service, method_name)
 
-    asyncio.run(method(*args))  # act
+    await method(*args)  # act
 
     mock_method = getattr(tasks_client, client_method)
     mock_method.assert_awaited_once_with(*client_args)

--- a/tests/services/mpt_api_service/test_template.py
+++ b/tests/services/mpt_api_service/test_template.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 from mpt_api_client.resources import AsyncCatalog, AsyncCommerce
 from mpt_api_client.resources.catalog.products import AsyncProductsService
@@ -28,7 +26,7 @@ def template_service_factory(mocker):
     return factory
 
 
-def test_get_template_returns_default_template(mocker, template_service_factory):
+async def test_get_template_returns_default_template(mocker, template_service_factory):
     service, templates_factory, templates_query = template_service_factory()
     templates_query.fetch_page = mocker.AsyncMock(return_value=[mocker.sentinel.api_template])
     from_payload = mocker.patch(
@@ -37,7 +35,7 @@ def test_get_template_returns_default_template(mocker, template_service_factory)
         return_value="template-model",
     )
 
-    result = asyncio.run(service.get_template("PROD-1", "Completed"))
+    result = await service.get_template("PROD-1", "Completed")
 
     assert result == "template-model"
     templates_factory.assert_called_once_with("PROD-1")
@@ -47,7 +45,7 @@ def test_get_template_returns_default_template(mocker, template_service_factory)
     from_payload.assert_called_once_with(mocker.sentinel.api_template)
 
 
-def test_get_template_returns_named_template(mocker, template_service_factory):
+async def test_get_template_returns_named_template(mocker, template_service_factory):
     api_template = mocker.Mock()
     service, _, templates_query = template_service_factory()
     templates_query.fetch_page = mocker.AsyncMock(return_value=[api_template])
@@ -57,7 +55,7 @@ def test_get_template_returns_named_template(mocker, template_service_factory):
         return_value="named-template",
     )
 
-    result = asyncio.run(service.get_template("PROD-1", "Completed", name="Welcome"))
+    result = await service.get_template("PROD-1", "Completed", name="Welcome")
 
     assert result == "named-template"
     templates_query.filter.assert_called_once_with(mocker.ANY)
@@ -66,7 +64,7 @@ def test_get_template_returns_named_template(mocker, template_service_factory):
     from_payload.assert_called_once_with(api_template)
 
 
-def test_get_template_returns_none_when_missing(mocker, template_service_factory):
+async def test_get_template_returns_none_when_missing(mocker, template_service_factory):
     service, _, templates_query = template_service_factory()
     templates_query.fetch_page = mocker.AsyncMock(return_value=[])
     from_payload = mocker.patch(
@@ -74,13 +72,13 @@ def test_get_template_returns_none_when_missing(mocker, template_service_factory
         autospec=True,
     )
 
-    result = asyncio.run(service.get_template("PROD-1", "Completed"))
+    result = await service.get_template("PROD-1", "Completed")
 
     assert result is None
     from_payload.assert_not_called()
 
 
-def test_get_asset_template_by_name_returns_one(mocker, template_service_factory):
+async def test_get_asset_template_by_name_returns_one(mocker, template_service_factory):
     api_template = mocker.Mock()
     service, _, templates_query = template_service_factory()
     templates_query.fetch_page = mocker.AsyncMock(return_value=[api_template])
@@ -90,7 +88,7 @@ def test_get_asset_template_by_name_returns_one(mocker, template_service_factory
         return_value="asset-template",
     )
 
-    result = asyncio.run(service.get_asset_template_by_name("PROD-1", "Asset Template"))
+    result = await service.get_asset_template_by_name("PROD-1", "Asset Template")
 
     assert result == "asset-template"
     templates_query.filter.assert_called_once_with(mocker.ANY)
@@ -98,7 +96,7 @@ def test_get_asset_template_by_name_returns_one(mocker, template_service_factory
     from_payload.assert_called_once_with(api_template)
 
 
-def test_get_asset_template_by_name_returns_none(mocker, template_service_factory):
+async def test_get_asset_template_by_name_returns_none(mocker, template_service_factory):
     service, _, templates_query = template_service_factory()
     templates_query.fetch_page = mocker.AsyncMock(return_value=[])
     from_payload = mocker.patch(
@@ -106,13 +104,13 @@ def test_get_asset_template_by_name_returns_none(mocker, template_service_factor
         autospec=True,
     )
 
-    result = asyncio.run(service.get_asset_template_by_name("PROD-1", "Asset Template"))
+    result = await service.get_asset_template_by_name("PROD-1", "Asset Template")
 
     assert result is None
     from_payload.assert_not_called()
 
 
-def test_get_order_querying_template_returns_one(mocker, template_service_factory):
+async def test_get_order_querying_template_returns_one(mocker, template_service_factory):
     api_template = mocker.Mock()
     service, _, templates_query = template_service_factory()
     templates_query.fetch_page = mocker.AsyncMock(return_value=[api_template])
@@ -122,7 +120,7 @@ def test_get_order_querying_template_returns_one(mocker, template_service_factor
         return_value="querying-template",
     )
 
-    result = asyncio.run(service.get_order_querying_template("PROD-1"))
+    result = await service.get_order_querying_template("PROD-1")
 
     assert result == "querying-template"
     templates_query.filter.assert_called_once_with(mocker.ANY)
@@ -130,7 +128,7 @@ def test_get_order_querying_template_returns_one(mocker, template_service_factor
     from_payload.assert_called_once_with(api_template)
 
 
-def test_get_order_querying_template_returns_none(mocker, template_service_factory):
+async def test_get_order_querying_template_returns_none(mocker, template_service_factory):
     service, _, templates_query = template_service_factory()
     templates_query.fetch_page = mocker.AsyncMock(return_value=[])
     from_payload = mocker.patch(
@@ -138,13 +136,13 @@ def test_get_order_querying_template_returns_none(mocker, template_service_facto
         autospec=True,
     )
 
-    result = asyncio.run(service.get_order_querying_template("PROD-1"))
+    result = await service.get_order_querying_template("PROD-1")
 
     assert result is None
     from_payload.assert_not_called()
 
 
-def test_set_order_template_updates_order(mocker):
+async def test_set_order_template_updates_order(mocker):
     order_template = mocker.Mock(spec=Template)
     order_template.to_dict.return_value = {"id": "TPL-1"}
     orders_client = mocker.AsyncMock(spec=AsyncOrdersService)
@@ -155,7 +153,7 @@ def test_set_order_template_updates_order(mocker):
     client.commerce = commerce_client
     service = TemplateService(client)
 
-    asyncio.run(service.set_order_template("ORD-1", order_template))  # act
+    await service.set_order_template("ORD-1", order_template)  # act
 
     order_template.to_dict.assert_called_once_with()
     orders_client.update.assert_awaited_once_with("ORD-1", {"template": {"id": "TPL-1"}})

--- a/uv.lock
+++ b/uv.lock
@@ -1433,6 +1433,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-deadfixtures" },
     { name = "pytest-mock" },
@@ -1471,6 +1472,7 @@ dev = [
     { name = "mypy", specifier = "==2.1.*" },
     { name = "pre-commit", specifier = "==4.6.*" },
     { name = "pytest", specifier = "==9.0.*" },
+    { name = "pytest-asyncio", specifier = "==1.3.*" },
     { name = "pytest-cov", specifier = "==7.1.*" },
     { name = "pytest-deadfixtures", specifier = "==3.1.*" },
     { name = "pytest-mock", specifier = "==3.15.*" },
@@ -2344,6 +2346,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
🤖 **AI-generated PR** — Please review carefully.

## Summary
- Add pytest-asyncio to the dev dependencies and configure pytest asyncio mode.
- Convert async tests from asyncio.run(...) wrappers to native async pytest tests.
- Update uv.lock for pytest-asyncio 1.3.0.

## Validation
- make check
- uv run pytest .

Note: make test initially failed locally because the existing Docker dev image did not include the new dependency yet; the updated lock/config passed with uv run pytest .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-20733](https://softwareone.atlassian.net/browse/MPT-20733)

- Added pytest-asyncio 1.3.0 to development dependencies and configured pytest with `asyncio_mode = "auto"` to enable native async test support
- Refactored test suite across 20+ test modules to use native async/await patterns instead of `asyncio.run()` wrappers
- Converted synchronous test functions to `async def` tests that directly await async function calls for improved readability and test execution
- Updated test assertions to use `assert_awaited_once_with()` for async mock verification
- Affected test modules include event builders, tracing, pipeline context, step execution, and service implementations (accounts, agreements, assets, orders, products, subscriptions, templates, and tasks)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/mpt-extension-sdk/pull/194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-20733]: https://softwareone.atlassian.net/browse/MPT-20733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ