### PR TITLE
MPT-21180: fix retrieve account token exp 

### DIFF
--- a/mpt_extension_sdk/services/mpt_api_service/agreement.py
+++ b/mpt_extension_sdk/services/mpt_api_service/agreement.py
@@ -26,15 +26,16 @@ class AgreementService(BaseService[Agreement]):
         agreement = await self._client.commerce.agreements.get(
             agreement_id,
             select=[
-                "client",
-                "seller",
-                "buyer",
-                "listing",
-                "product",
-                "subscriptions",
                 "assets",
+                "buyer",
+                "client",
+                "licensee",
                 "lines",
+                "listing",
                 "parameters",
+                "product",
+                "seller",
+                "subscriptions",
             ],
         )
         logger.debug("Fetched agreement %s: %s", agreement_id, agreement.to_dict())

--- a/mpt_extension_sdk/services/mpt_api_service/installation.py
+++ b/mpt_extension_sdk/services/mpt_api_service/installation.py
@@ -1,3 +1,4 @@
+from mpt_extension_sdk.jwt import decode_unverified_jwt_claims
 from mpt_extension_sdk.models.account import AccountToken
 from mpt_extension_sdk.services.mpt_api_service.base import BaseService
 
@@ -9,8 +10,9 @@ class InstallationService(BaseService[AccountToken]):
         """Create an account-scoped token for an installation."""
         installations = self._client.integration.installations()
         response = await installations.http_client.request(
-            "post",
-            installations.path,
-            query_params={"account.id": account_id},
+            "post", installations.path, query_params={"account.id": account_id}
         )
-        return AccountToken.from_payload(response.json())
+        payload = response.json()
+        claims = decode_unverified_jwt_claims(payload["token"])
+        payload = {**payload, "exp": claims.get("exp")}
+        return AccountToken.from_payload(payload)

--- a/tests/services/mpt_api_service/test_account_scoped.py
+++ b/tests/services/mpt_api_service/test_account_scoped.py
@@ -1,10 +1,10 @@
-import base64
 import datetime as dt
-import json
 
 import pytest
 from mpt_api_client.http.async_client import AsyncHTTPClient
+from mpt_api_client.http.types import Response
 
+from mpt_extension_sdk.api.auth import Account, AccountType, AuthContext
 from mpt_extension_sdk.models.account import AccountToken
 from mpt_extension_sdk.services.mpt_api_service.account_scoped_client import (
     AccountScopedAsyncHTTPClient,
@@ -14,43 +14,51 @@ from mpt_extension_sdk.services.mpt_api_service.account_scoped_client import (
 from mpt_extension_sdk.services.mpt_api_service.installation import InstallationService
 
 
-def build_token(exp: int) -> str:
-    payload = json.dumps({"exp": exp}).encode("utf-8")
-    encoded_payload = base64.urlsafe_b64encode(payload).decode("utf-8").rstrip("=")
-    return f"header.{encoded_payload}.signature"
+@pytest.fixture
+def account_token_factory():
+    def factory(token: str | None = None, expires_at: dt.datetime | None = None) -> AccountToken:
+        if expires_at is None:
+            expires_at = dt.datetime.now(dt.UTC) + dt.timedelta(minutes=10)
+        return AccountToken(
+            token="account-token" if token is None else token,
+            exp=int(expires_at.timestamp()),
+            expires_at=expires_at,
+        )
+
+    return factory
 
 
-def build_account_token(token: str, expires_at: dt.datetime) -> AccountToken:
-    return AccountToken(
-        token=token,
-        exp=int(expires_at.timestamp()),
-        expires_at=expires_at,
-    )
+@pytest.fixture
+def token_provider_factory(mocker, account_token_factory, runtime_settings):  # noqa: WPS210
+    def factory(account_token: AccountToken | None = None):
+        provider_token = account_token_factory() if account_token is None else account_token
+        auth = mocker.Mock(
+            spec=AuthContext,
+            token="request-token",
+            extension_id="EXT-1",
+            account=Account(id="ACC-1", type=AccountType.CLIENT),
+        )
+        installations = mocker.Mock(
+            spec=["create_token"], create_token=mocker.AsyncMock(return_value=provider_token)
+        )
+        service_type = mocker.Mock(spec=["from_config"])
+        service_type.from_config.return_value = mocker.Mock(
+            spec=["installations"], installations=installations
+        )
+        provider = AccountTokenProvider(
+            runtime_settings=runtime_settings, auth=auth, service_type=service_type
+        )
+        return provider, service_type, installations
+
+    return factory
 
 
-def build_token_provider(mocker, runtime_settings):  # noqa: WPS210
-    """Build a token provider with mocked installation token creation."""
-    expires_at = dt.datetime.now(dt.UTC) + dt.timedelta(minutes=10)
-    account_token = build_account_token("account-token", expires_at)
-    auth = mocker.Mock()
-    auth.token = "request-token"
-    auth.extension_id = "EXT-1"
-    auth.account.id = "ACC-1"
-    installations = mocker.Mock()
-    installations.create_token = mocker.AsyncMock(return_value=account_token)
-    service_type = mocker.Mock()
-    service_type.from_config.return_value = mocker.Mock(installations=installations)
-    provider = AccountTokenProvider(
-        runtime_settings=runtime_settings,
-        auth=auth,
-        service_type=service_type,
-    )
-    return provider, service_type, installations
+@pytest.fixture
+def provider_tokens_factory():
+    async def factory(provider):
+        return [await provider.get_token(), await provider.get_token()]
 
-
-async def get_provider_tokens(provider):
-    """Request the account token twice."""
-    return [await provider.get_token(), await provider.get_token()]
+    return factory
 
 
 @pytest.fixture
@@ -60,18 +68,23 @@ def clear_account_token_cache():
     AccountTokenProvider.clear_cache()
 
 
-async def test_create_token_query_params(mocker, async_mpt_client):
-    installations = mocker.Mock()
-    installations.path = "/public/v1/integration/installations/-/token"
-    response = mocker.Mock()
-    response.json.return_value = {"token": build_token(4102444800), "exp": 4102444800}
-    installations.http_client.request = mocker.AsyncMock(return_value=response)
+async def test_create_token_query_params(mocker, async_mpt_client, jwt_token_factory):
+    token = jwt_token_factory({"exp": 4102444800})
+    response = mocker.Mock(spec=Response)
+    response.json.return_value = {"token": token}
+    http_client = mocker.Mock(spec=["request"], request=mocker.AsyncMock(return_value=response))
+    installations = mocker.Mock(
+        spec=["path", "http_client"],
+        path="/public/v1/integration/installations/-/token",
+        http_client=http_client,
+    )
     async_mpt_client.integration.installations.return_value = installations
-    service = InstallationService(async_mpt_client)
 
-    result = await service.create_token("ACC-1")
+    result = await InstallationService(async_mpt_client).create_token("ACC-1")
 
-    assert result.token == build_token(4102444800)
+    assert result.token == token
+    assert result.exp == 4102444800
+    assert result.expires_at == dt.datetime.fromtimestamp(4102444800, tz=dt.UTC)
     installations.http_client.request.assert_awaited_once_with(
         "post",
         "/public/v1/integration/installations/-/token",
@@ -79,12 +92,14 @@ async def test_create_token_query_params(mocker, async_mpt_client):
     )
 
 
-async def test_provider_caches_token(clear_account_token_cache, mocker, runtime_settings):
-    provider, service_type, installations = build_token_provider(mocker, runtime_settings)
+async def test_provider_caches_token(
+    clear_account_token_cache, runtime_settings, token_provider_factory, provider_tokens_factory
+):
+    provider, service_type, installations = token_provider_factory()
 
-    token_results = await get_provider_tokens(provider)  # act
+    result = await provider_tokens_factory(provider)
 
-    assert token_results == ["account-token", "account-token"]
+    assert result == ["account-token", "account-token"]
     service_type.from_config.assert_called_once_with(
         base_url=runtime_settings.mpt_api_base_url, api_token=runtime_settings.ext_api_key
     )
@@ -92,8 +107,9 @@ async def test_provider_caches_token(clear_account_token_cache, mocker, runtime_
 
 
 def test_mpt_client_uses_refreshing_http_client(mocker):
-    token_provider = mocker.Mock()
-    token_provider.get_token = mocker.AsyncMock(return_value="account-token")
+    token_provider = mocker.Mock(
+        spec=["get_token"], get_token=mocker.AsyncMock(return_value="account-token")
+    )
 
     result = AccountScopedAsyncMPTClient.from_token_provider(
         base_url="https://api.example.com",
@@ -105,9 +121,11 @@ def test_mpt_client_uses_refreshing_http_client(mocker):
 
 
 async def test_http_client_refreshes_each_request(mocker):
-    token_provider = mocker.Mock()
-    token_provider.get_token = mocker.AsyncMock(side_effect=["account-token-1", "account-token-2"])
-    response = mocker.Mock()
+    token_provider = mocker.Mock(
+        spec=["get_token"],
+        get_token=mocker.AsyncMock(side_effect=["account-token-1", "account-token-2"]),
+    )
+    response = mocker.Mock(spec=Response)
     request = mocker.patch.object(AsyncHTTPClient, "request", autospec=True, return_value=response)
     client = AccountScopedAsyncHTTPClient(
         base_url="https://api.example.com",
@@ -115,12 +133,12 @@ async def test_http_client_refreshes_each_request(mocker):
         token_provider=token_provider,
     )
 
-    request_results = [
+    result = [
         await client.request("get", "/orders/ORD-1", headers={"x-test": "1"}),
         await client.request("get", "/orders/ORD-1", headers={"x-test": "1"}),
-    ]  # act
+    ]
 
-    assert request_results == [response, response]
+    assert result == [response, response]
     assert token_provider.get_token.await_count == 2
     assert request.await_count == 2
     assert request.await_args_list[0].kwargs["headers"] == {

--- a/tests/services/mpt_api_service/test_agreement.py
+++ b/tests/services/mpt_api_service/test_agreement.py
@@ -32,15 +32,16 @@ async def test_get_by_id(mocker, agreement_service_factory):
     agreements_client.get.assert_awaited_once_with(
         "AGR-1",
         select=[
-            "client",
-            "seller",
-            "buyer",
-            "listing",
-            "product",
-            "subscriptions",
             "assets",
+            "buyer",
+            "client",
+            "licensee",
             "lines",
+            "listing",
             "parameters",
+            "product",
+            "seller",
+            "subscriptions",
         ],
     )
     from_payload.assert_called_once_with(api_agreement)


### PR DESCRIPTION
🤖 **AI-generated PR** — Please review carefully.

## Summary
- derive installation account token `exp` from the JWT payload when Marketplace does not return it separately
- include `licensee` in agreement fetch select fields
- update service tests for decoded token expiration and agreement selected fields

## Tests
- make test
- make check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21180](https://softwareone.atlassian.net/browse/MPT-21180)

- Derive installation account token expiration (`exp`) from decoded JWT claims when the Marketplace response lacks an explicit expiration field (InstallationService.create_token).
- Include `licensee` in the select fields when fetching agreement data (AgreementService.get_by_id).
- Update service tests to assert the decoded token expiration and that agreement fetch uses the updated select fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/mpt-extension-sdk/pull/197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21180]: https://softwareone.atlassian.net/browse/MPT-21180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ