### PR TITLE
MPT-21690 fix: regenerate meta.yaml on every runtime app import

### DIFF
--- a/mpt_extension_sdk/runtime/main.py
+++ b/mpt_extension_sdk/runtime/main.py
@@ -1,4 +1,15 @@
+from fastapi import FastAPI
+
 from mpt_extension_sdk.runtime.app import create_runtime_app
+from mpt_extension_sdk.runtime.runner import create_meta_file
 from mpt_extension_sdk.settings.runtime import get_runtime_settings
 
-app = create_runtime_app(runtime_settings=get_runtime_settings())
+
+def bootstrap_runtime_app() -> FastAPI:
+    """Build the ASGI app and persist meta.yaml on every uvicorn import."""
+    settings = get_runtime_settings()
+    create_meta_file(settings)
+    return create_runtime_app(runtime_settings=settings)
+
+
+app = bootstrap_runtime_app()

--- a/mpt_extension_sdk/runtime/runner.py
+++ b/mpt_extension_sdk/runtime/runner.py
@@ -17,7 +17,6 @@ def run_extension(*, local: bool) -> None:
             otherwise run with Ziticorn for OpenZiti connectivity.
     """
     settings = get_runtime_settings()
-    create_meta_file(settings)
     if local:
         run_fastapi(
             "mpt_extension_sdk.runtime.main:app",

--- a/tests/runtime/test_main.py
+++ b/tests/runtime/test_main.py
@@ -9,6 +9,10 @@ def test_runtime_main_builds_app_from_settings(mocker, runtime_settings):
         autospec=True,
         return_value=expected_app,
     )
+    create_meta_file = mocker.patch(
+        "mpt_extension_sdk.runtime.runner.create_meta_file",
+        autospec=True,
+    )
     get_runtime_settings = mocker.patch(
         "mpt_extension_sdk.settings.runtime.get_runtime_settings",
         autospec=True,
@@ -20,4 +24,5 @@ def test_runtime_main_builds_app_from_settings(mocker, runtime_settings):
 
     assert result.app is expected_app
     get_runtime_settings.assert_called_once_with()
+    create_meta_file.assert_called_once_with(runtime_settings)
     create_runtime_app.assert_called_once_with(runtime_settings=runtime_settings)

--- a/tests/runtime/test_runner.py
+++ b/tests/runtime/test_runner.py
@@ -27,7 +27,7 @@ def test_run_extension_local_mode(runtime_settings, runner_patches):
 
     runner.run_extension(local=True)  # act
 
-    create_meta_file.assert_called_once_with(runtime_settings)
+    create_meta_file.assert_not_called()
     run_fastapi.assert_called_once_with(
         "mpt_extension_sdk.runtime.main:app",
         host=runtime_settings.local_host,
@@ -47,7 +47,7 @@ def test_run_extension_platform_mode(runtime_settings, runner_patches):
 
     runner.run_extension(local=False)  # act
 
-    create_meta_file.assert_called_once_with(runtime_settings)
+    create_meta_file.assert_not_called()
     register_instance.assert_called_once_with(settings=runtime_settings)
     run_ziti.assert_called_once_with(
         "mpt_extension_sdk.runtime.main:app",


### PR DESCRIPTION
## Summary
Fixes [MPT-21690](https://softwareone.atlassian.net/browse/MPT-21690): `meta.yaml` was not regenerated on local uvicorn reload, so router / Plug / socket / event definition changes in an extension were picked up by the reloaded Python app but the on-disk `meta.yaml` stayed stale until the container was restarted or `uv run mpt-ext meta generate` was run manually.

## Cause
`create_meta_file()` was only invoked once, in `runtime/runner.py::run_extension`, in the **parent** CLI process before launching uvicorn with `reload=True`. When uvicorn reloads on file change, it re-imports `mpt_extension_sdk/runtime/main.py`, which already rebuilds `meta_config` in memory via `RuntimeSettings.load` / `ExtensionApp.to_meta_config` — but the fresh config was never persisted to disk in the reloaded process.

## Fix
Move the `create_meta_file()` call from `runtime/runner.py::run_extension` into `runtime/main.py`, so `meta.yaml` is written on every uvicorn import — both at initial boot and after each reload. The Ziti path uses the same module, so production behavior remains equivalent (meta still persisted at boot).

## Changes
- `mpt_extension_sdk/runtime/main.py`: call `create_meta_file(settings)` immediately before `create_runtime_app(...)`.
- `mpt_extension_sdk/runtime/runner.py`: drop the now-redundant `create_meta_file(settings)` call inside `run_extension`.
- Tests updated:
  - `tests/runtime/test_main.py`: assert `create_meta_file` is invoked at app-module import.
  - `tests/runtime/test_runner.py`: assert `create_meta_file` is **not** called by `run_extension` (responsibility moved).

## Test plan
- `make test` — 325 passed, 98% coverage.
- `make check` — ruff format / ruff check / flake8 / mypy / uv lock all clean.

[MPT-21690]: https://softwareone.atlassian.net/browse/MPT-21690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21690](https://softwareone.atlassian.net/browse/MPT-21690)

- Regenerate metadata on every uvicorn reload: move create_meta_file() into mpt_extension_sdk/runtime/main.py so meta.yaml is written on every import (initial boot and each uvicorn reload), keeping on-disk metadata in sync with in-memory runtime config.
- Remove redundant write in runner: remove create_meta_file() call from runtime/runner.py::run_extension.
- Refactor app bootstrap: add bootstrap_runtime_app() in runtime/main.py to load settings once, call create_meta_file(settings), then create the FastAPI app with the same settings.
- Tests updated: tests/runtime/test_main.py now asserts create_meta_file is invoked at app-module import; tests/runtime/test_runner.py verifies run_extension no longer calls create_meta_file.
- CI: make test — 325 passed, 98% coverage; lint/type checks (ruff/flake8/mypy/uv lock) clean.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softwareone-platform/mpt-extension-sdk/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->