### PR TITLE
MPT-21679: upgrade mpt-api-client

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         pass_filenames: false
         additional_dependencies:
           - fastapi[standard]==0.131.*
-          - mpt-api-client==6.0.*
+          - mpt-api-client==6.3.*
           - mrok==0.9.6
           - opentelemetry-api==1.40.0
           - opentelemetry-exporter-otlp-proto-http==1.40.0

--- a/mock_app/mocks/api_service.py
+++ b/mock_app/mocks/api_service.py
@@ -6,9 +6,9 @@ from mpt_extension_sdk.models.account import AccountToken
 from mpt_extension_sdk.models.base import BaseModel
 from mpt_extension_sdk.services.api_client_v2.mpt_api_client import AsyncMPTClient
 from mpt_extension_sdk.services.mpt_api_service import MPTAPIService
+from mpt_extension_sdk.services.mpt_api_service.account_token import AccountTokenService
 from mpt_extension_sdk.services.mpt_api_service.agreement import AgreementService
 from mpt_extension_sdk.services.mpt_api_service.base import PaginatedCollection
-from mpt_extension_sdk.services.mpt_api_service.installation import InstallationService
 from mpt_extension_sdk.services.mpt_api_service.order import OrderService
 
 
@@ -18,8 +18,19 @@ class ExtMPTAPIService(MPTAPIService):
     def __init__(self, client: AsyncMPTClient, *args: Any, **kwargs: Any) -> None:
         super().__init__(client)
         self.agreements = MockAgreementService(client)
-        self.installations = MockInstallationService(client)
+        self.account_token = MockAccountTokenService(client)
         self.orders = MockOrderService(client)
+
+
+class MockAccountTokenService(AccountTokenService):
+    """Mock account token service."""
+
+    @override
+    async def create_token(self, account_id: str) -> AccountToken:
+        return AccountToken.from_payload({
+            "token": "mock-account-token",
+            "exp": 1877516378,
+        })
 
 
 class MockAgreementService(AgreementService):
@@ -57,17 +68,6 @@ class MockAgreementService(AgreementService):
             "product": {"id": "PROD-111", "name": "Test Product"},
         }
         return Agreement.from_payload(payload)
-
-
-class MockInstallationService(InstallationService):
-    """Mock installation service."""
-
-    @override
-    async def create_token(self, account_id: str) -> AccountToken:
-        return AccountToken.from_payload({
-            "token": "mock-account-token",
-            "exp": 1877516378,
-        })
 
 
 class MockOrderService(OrderService):

--- a/mpt_extension_sdk/services/api_client_v2/integration/extensions.py
+++ b/mpt_extension_sdk/services/api_client_v2/integration/extensions.py
@@ -1,19 +1,17 @@
-from mpt_api_client.resources.integration import (
-    AsyncIntegration as BaseAsyncIntegration,
-)
+from mpt_api_client.resources.integration import AsyncIntegration as BaseAsyncIntegration
 
 from mpt_extension_sdk.services.api_client_v2.integration.extensions_installations import (
-    AsyncIntegrationInstallationsService,
+    AsyncIntegrationInstallationsTokenService,
 )
 
 
 class AsyncIntegration(BaseAsyncIntegration):
     """Extensions service."""
 
-    def installations(self) -> AsyncIntegrationInstallationsService:
+    def installations_token(self) -> AsyncIntegrationInstallationsTokenService:
         """Installation service.
 
         Returns:
             Extension Installation service.
         """
-        return AsyncIntegrationInstallationsService(http_client=self.http_client)
+        return AsyncIntegrationInstallationsTokenService(http_client=self.http_client)

--- a/mpt_extension_sdk/services/api_client_v2/integration/extensions_installations.py
+++ b/mpt_extension_sdk/services/api_client_v2/integration/extensions_installations.py
@@ -3,20 +3,20 @@ from mpt_api_client.http.mixins import AsyncCreateMixin
 from mpt_api_client.models import Model
 
 
-class IntegrationInstallations(Model):
-    """Integration installations model."""
+class IntegrationInstallationsToken(Model):
+    """Integration installations token model."""
 
 
-class IntegrationInstallationsServiceConfig:
-    """Integration installations service config."""
+class IntegrationInstallationsTokenServiceConfig:
+    """Integration installations token service config."""
 
     _endpoint = "/public/v1/integration/installations/-/token"
-    _model_class = IntegrationInstallations
+    _model_class = IntegrationInstallationsToken
 
 
-class AsyncIntegrationInstallationsService(
-    AsyncCreateMixin[IntegrationInstallations],
-    AsyncService[IntegrationInstallations],
-    IntegrationInstallationsServiceConfig,
+class AsyncIntegrationInstallationsTokenService(
+    AsyncCreateMixin[IntegrationInstallationsToken],
+    AsyncService[IntegrationInstallationsToken],
+    IntegrationInstallationsTokenServiceConfig,
 ):
-    """Extensions installations service."""
+    """Extensions installations token service."""

--- a/mpt_extension_sdk/services/mpt_api_service/account_scoped_client.py
+++ b/mpt_extension_sdk/services/mpt_api_service/account_scoped_client.py
@@ -73,7 +73,7 @@ class AccountTokenProvider:
             base_url=self._runtime_settings.mpt_api_base_url,
             api_token=self._runtime_settings.ext_api_key,
         )
-        return await mpt_api_service.installations.create_token(self._auth.account.id)
+        return await mpt_api_service.account_token.create_token(self._auth.account.id)
 
     def _is_token_valid(self, expires_at: dt.datetime) -> bool:
         expected_time = dt.datetime.now(dt.UTC).timestamp() + self._min_remaining_validity_seconds

--- a/mpt_extension_sdk/services/mpt_api_service/account_token.py
+++ b/mpt_extension_sdk/services/mpt_api_service/account_token.py
@@ -3,12 +3,12 @@ from mpt_extension_sdk.models.account import AccountToken
 from mpt_extension_sdk.services.mpt_api_service.base import BaseService
 
 
-class InstallationService(BaseService[AccountToken]):
-    """Installation service."""
+class AccountTokenService(BaseService[AccountToken]):
+    """Account-scoped token service."""
 
     async def create_token(self, account_id: str) -> AccountToken:
         """Create an account-scoped token for an installation."""
-        installations = self._client.integration.installations()
+        installations = self._client.integration.installations_token()
         response = await installations.http_client.request(
             "post", installations.path, query_params={"account.id": account_id}
         )

--- a/mpt_extension_sdk/services/mpt_api_service/api_service.py
+++ b/mpt_extension_sdk/services/mpt_api_service/api_service.py
@@ -6,10 +6,10 @@ from mpt_extension_sdk.services.mpt_api_service.account_scoped_client import (
     AccountScopedAsyncMPTClient,
     AccountTokenProvider,
 )
+from mpt_extension_sdk.services.mpt_api_service.account_token import AccountTokenService
 from mpt_extension_sdk.services.mpt_api_service.agreement import AgreementService
 from mpt_extension_sdk.services.mpt_api_service.asset import AssetService
 from mpt_extension_sdk.services.mpt_api_service.client_factory import build_mpt_client
-from mpt_extension_sdk.services.mpt_api_service.installation import InstallationService
 from mpt_extension_sdk.services.mpt_api_service.order import OrderService
 from mpt_extension_sdk.services.mpt_api_service.product import (
     ProductItemService,
@@ -33,7 +33,7 @@ class MPTAPIService:  # noqa: WPS215, WPS230
         self.client = client
         self.agreements = AgreementService(client)
         self.assets = AssetService(client)
-        self.installations = InstallationService(client)
+        self.account_token = AccountTokenService(client)
         self.products = ProductService(client)
         self.product_items = ProductItemService(client)
         self.orders = OrderService(client)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "docs/usage.md"
 license = {text = "Apache-2.0 license"}
 dependencies = [
     "fastapi[standard]==0.131.*",
-    "mpt-api-client==6.1.*",
+    "mpt-api-client==6.3.*",
     "mrok==0.9.6",
     "opentelemetry-api==1.40.0",
     "opentelemetry-exporter-otlp-proto-http==1.40.0",

--- a/tests/services/mpt_api_service/test_account_scoped.py
+++ b/tests/services/mpt_api_service/test_account_scoped.py
@@ -11,7 +11,7 @@ from mpt_extension_sdk.services.mpt_api_service.account_scoped_client import (
     AccountScopedAsyncMPTClient,
     AccountTokenProvider,
 )
-from mpt_extension_sdk.services.mpt_api_service.installation import InstallationService
+from mpt_extension_sdk.services.mpt_api_service.account_token import AccountTokenService
 
 
 @pytest.fixture
@@ -38,17 +38,17 @@ def token_provider_factory(mocker, account_token_factory, runtime_settings):  # 
             extension_id="EXT-1",
             account=Account(id="ACC-1", type=AccountType.CLIENT),
         )
-        installations = mocker.Mock(
+        account_token = mocker.Mock(
             spec=["create_token"], create_token=mocker.AsyncMock(return_value=provider_token)
         )
         service_type = mocker.Mock(spec=["from_config"])
         service_type.from_config.return_value = mocker.Mock(
-            spec=["installations"], installations=installations
+            spec=["account_token"], account_token=account_token
         )
         provider = AccountTokenProvider(
             runtime_settings=runtime_settings, auth=auth, service_type=service_type
         )
-        return provider, service_type, installations
+        return provider, service_type, account_token
 
     return factory
 
@@ -78,9 +78,9 @@ async def test_create_token_query_params(mocker, async_mpt_client, jwt_token_fac
         path="/public/v1/integration/installations/-/token",
         http_client=http_client,
     )
-    async_mpt_client.integration.installations.return_value = installations
+    async_mpt_client.integration.installations_token.return_value = installations
 
-    result = await InstallationService(async_mpt_client).create_token("ACC-1")
+    result = await AccountTokenService(async_mpt_client).create_token("ACC-1")
 
     assert result.token == token
     assert result.exp == 4102444800

--- a/tests/services/mpt_api_service/test_api_service.py
+++ b/tests/services/mpt_api_service/test_api_service.py
@@ -12,7 +12,7 @@ def test_api_service_composes_expected_services(mocker):  # noqa: WPS218
     assert result.client is client
     assert hasattr(result, "agreements")
     assert hasattr(result, "assets")
-    assert hasattr(result, "installations")
+    assert hasattr(result, "account_token")
     assert hasattr(result, "products")
     assert hasattr(result, "product_items")
     assert hasattr(result, "orders")

--- a/uv.lock
+++ b/uv.lock
@@ -1388,15 +1388,15 @@ wheels = [
 
 [[package]]
 name = "mpt-api-client"
-version = "6.1.0"
+version = "6.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "httpx-retries" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/bf2e0afa1b01dfa40671a2c6850909631eee0f6869a1a384a03f64f3a838/mpt_api_client-6.1.0.tar.gz", hash = "sha256:722fa5272789ff923d2941f7e58adedeac77e6ffcdfbbb8e444a444304d0ef08", size = 60724, upload-time = "2026-05-04T12:15:41.821Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/6f/3a398fdff0374ef4d4a9f1eb07ec89b5d74f9e3c30642d55673754738758/mpt_api_client-6.3.0.tar.gz", hash = "sha256:5e1633a4efa7c167982887d4774df1544df8237f85e49f6912dab10a6cc3a89a", size = 62779, upload-time = "2026-06-02T15:44:09.685Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/12/62a2e9381222ba028b9db99c385378bcacbaee639b9842debd6c6e285fd9/mpt_api_client-6.1.0-py3-none-any.whl", hash = "sha256:88a01c447b943d827960825ea257eee0235ce4f53cf1abc7db835f6803e93d8e", size = 139178, upload-time = "2026-05-04T12:15:40.606Z" },
+    { url = "https://files.pythonhosted.org/packages/15/91/5733e8086d14addd456d5a73e5d93ca9e544949edcf5b382aa252554dd27/mpt_api_client-6.3.0-py3-none-any.whl", hash = "sha256:2fe338c0f867055d9f2738ebb82c66b6bd88c69418fd7ea72ea8dd9909d913f6", size = 143352, upload-time = "2026-06-02T15:44:08.545Z" },
 ]
 
 [[package]]
@@ -1448,7 +1448,7 @@ dev = [
 requires-dist = [
     { name = "azure-monitor-opentelemetry-exporter", marker = "extra == 'azure-monitor'", specifier = "==1.0.0b51" },
     { name = "fastapi", extras = ["standard"], specifier = "==0.131.*" },
-    { name = "mpt-api-client", specifier = "==6.1.*" },
+    { name = "mpt-api-client", specifier = "==6.3.*" },
     { name = "mrok", specifier = "==0.9.6" },
     { name = "opentelemetry-api", specifier = "==1.40.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = "==1.40.0" },


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21679](https://softwareone.atlassian.net/browse/MPT-21679)

- Upgrade dependency: mpt-api-client 6.1.* → 6.3.* (pyproject.toml and mypy pre-commit hook)
- Replace InstallationService with AccountTokenService for account-scoped token creation
- MPTAPIService exposes account_token (AccountTokenService) instead of installations
- Integration API renamed: AsyncIntegration.installations() → AsyncIntegration.installations_token()
- Add IntegrationInstallationsToken model and token-specific service classes; remove old installations classes
- AccountTokenProvider now calls mpt_api_service.account_token.create_token(account_id)
- Update mocks and tests to use MockAccountTokenService / AccountTokenService and installations_token integration call
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21679]: https://softwareone.atlassian.net/browse/MPT-21679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
