### PR TITLE
MPT-21909 add Installations service exists_for_account lookup

### DIFF
--- a/docs/sdk_usage/marketplace-services.md
+++ b/docs/sdk_usage/marketplace-services.md
@@ -35,6 +35,24 @@ mpt_api_service = await MPTAPIService.from_account_id(base_url, account_id)
 so the resulting service refreshes its token per request like any other
 account-scoped service.
 
+## Installations
+
+Use `ctx.mpt_api_service.installations` to look up extension installations
+through the integration installations endpoint. To check whether an extension
+is already installed in a given account before deciding to invite it:
+
+```python
+already_installed = await ctx.mpt_api_service.installations.exists_for_account(
+    extension_id="EXT-1234",
+    account_id="ACC-5678",
+)
+```
+
+`exists_for_account` returns ``True`` whenever the API returns at least one
+matching installation regardless of installation status (`Invited`,
+`Installed`, `Expired`, `Uninstalled`). It returns ``False`` only for an empty
+result set. Other API errors are propagated unchanged.
+
 ## Operations-Authenticated Service Per Handler
 
 For the common case of acting as the Operations account from a Client-account

--- a/mpt_extension_sdk/models/__init__.py
+++ b/mpt_extension_sdk/models/__init__.py
@@ -3,6 +3,11 @@ from mpt_extension_sdk.models.agreement import Agreement, AgreementLine
 from mpt_extension_sdk.models.asset import Asset, AssetLine
 from mpt_extension_sdk.models.authorization import Authorization
 from mpt_extension_sdk.models.external_id import ExternalIds
+from mpt_extension_sdk.models.installation import (
+    Installation,
+    InstallationReference,
+    InstallationStatus,
+)
 from mpt_extension_sdk.models.licensee import Licensee
 from mpt_extension_sdk.models.order import Order, OrderLine
 from mpt_extension_sdk.models.parameter import ParameterBag
@@ -21,6 +26,9 @@ __all__ = [  # noqa: WPS410
     "Authorization",
     "BuyerAccount",
     "ExternalIds",
+    "Installation",
+    "InstallationReference",
+    "InstallationStatus",
     "Licensee",
     "Order",
     "OrderLine",

--- a/mpt_extension_sdk/models/installation.py
+++ b/mpt_extension_sdk/models/installation.py
@@ -1,0 +1,28 @@
+from enum import StrEnum
+
+from mpt_extension_sdk.models.base import BaseModel
+
+
+class InstallationStatus(StrEnum):
+    """Lifecycle status of an extension installation in a Marketplace account."""
+
+    INVITED = "Invited"
+    INSTALLED = "Installed"
+    UNINSTALLED = "Uninstalled"
+    EXPIRED = "Expired"
+
+
+class InstallationReference(BaseModel):
+    """Reference to another resource embedded in an installation payload."""
+
+    id: str
+
+
+class Installation(BaseModel):
+    """Installation of an extension in a Marketplace account."""
+
+    id: str | None = None
+    name: str | None = None
+    status: InstallationStatus | None = None
+    account: InstallationReference | None = None
+    extension: InstallationReference | None = None

--- a/mpt_extension_sdk/services/mpt_api_service/api_service.py
+++ b/mpt_extension_sdk/services/mpt_api_service/api_service.py
@@ -10,6 +10,7 @@ from mpt_extension_sdk.services.mpt_api_service.account_token import AccountToke
 from mpt_extension_sdk.services.mpt_api_service.agreement import AgreementService
 from mpt_extension_sdk.services.mpt_api_service.asset import AssetService
 from mpt_extension_sdk.services.mpt_api_service.client_factory import build_mpt_client
+from mpt_extension_sdk.services.mpt_api_service.installation import InstallationService
 from mpt_extension_sdk.services.mpt_api_service.order import OrderService
 from mpt_extension_sdk.services.mpt_api_service.product import (
     ProductItemService,
@@ -34,6 +35,7 @@ class MPTAPIService:  # noqa: WPS215, WPS230
         self.agreements = AgreementService(client)
         self.assets = AssetService(client)
         self.account_token = AccountTokenService(client)
+        self.installations = InstallationService(client)
         self.products = ProductService(client)
         self.product_items = ProductItemService(client)
         self.orders = OrderService(client)

--- a/mpt_extension_sdk/services/mpt_api_service/installation.py
+++ b/mpt_extension_sdk/services/mpt_api_service/installation.py
@@ -1,0 +1,26 @@
+from mpt_api_client import RQLQuery
+
+from mpt_extension_sdk.models.installation import Installation
+from mpt_extension_sdk.services.mpt_api_service.base import BaseService
+
+
+class InstallationService(BaseService[Installation]):
+    """Integration installations service."""
+
+    async def exists_for_account(self, extension_id: str, account_id: str) -> bool:
+        """Return whether an installation exists for the given extension and account.
+
+        Args:
+            extension_id: Target extension id.
+            account_id: Target Marketplace account id.
+
+        Returns:
+            ``True`` when at least one installation is returned by the API
+            regardless of installation status; ``False`` only when the
+            Marketplace API responds with an empty result set. Other API
+            errors are propagated to the caller.
+        """
+        page = await self._client.integration.installations.filter(
+            RQLQuery(extension__id=extension_id) & RQLQuery(account__id=account_id)
+        ).fetch_page(limit=0)
+        return page.meta.pagination.total != 0  # type: ignore[union-attr]

--- a/tests/services/mpt_api_service/test_api_service.py
+++ b/tests/services/mpt_api_service/test_api_service.py
@@ -14,6 +14,7 @@ def test_api_service_composes_expected_services(mocker):  # noqa: WPS218
     assert hasattr(result, "agreements")
     assert hasattr(result, "assets")
     assert hasattr(result, "account_token")
+    assert hasattr(result, "installations")
     assert hasattr(result, "products")
     assert hasattr(result, "product_items")
     assert hasattr(result, "orders")

--- a/tests/services/mpt_api_service/test_installation.py
+++ b/tests/services/mpt_api_service/test_installation.py
@@ -1,0 +1,83 @@
+from collections.abc import Callable
+
+import pytest
+from mpt_api_client import RQLQuery
+from mpt_api_client.http.types import Response
+from mpt_api_client.models.meta import Meta, Pagination
+from mpt_api_client.models.model_collection import ModelCollection
+from mpt_api_client.resources.integration.installations import (
+    AsyncInstallationsService,
+)
+from mpt_api_client.resources.integration.installations import (
+    Installation as ClientInstallation,
+)
+
+from mpt_extension_sdk.services.mpt_api_service.installation import InstallationService
+
+
+@pytest.fixture
+def installation_service_factory(mocker, async_mpt_client):
+    def factory():
+        installations_service = mocker.Mock(spec=AsyncInstallationsService)
+        async_mpt_client.integration.installations = installations_service
+        return InstallationService(async_mpt_client), installations_service
+
+    return factory
+
+
+@pytest.fixture
+def installation_collection_factory(mocker):
+    def factory(total: int):
+        return ModelCollection[ClientInstallation](
+            resources=[],
+            meta=Meta(
+                response=mocker.Mock(spec=Response),
+                pagination=Pagination(limit=0, offset=0, total=total),
+            ),
+        )
+
+    return factory
+
+
+async def test_exists_for_account_found(
+    mocker, installation_service_factory, installation_collection_factory
+):
+    service, installations_client = installation_service_factory()
+    page = installation_collection_factory(total=1)
+    filtered_collection = mocker.Mock(spec=["fetch_page"])
+    filtered_collection.fetch_page = mocker.AsyncMock(spec=Callable, return_value=page)
+    installations_client.filter = mocker.Mock(return_value=filtered_collection)
+
+    result = await service.exists_for_account(extension_id="EXT-1", account_id="ACC-1")
+
+    assert result is True
+    installations_client.filter.assert_called_once_with(
+        RQLQuery(extension__id="EXT-1") & RQLQuery(account__id="ACC-1")
+    )
+    filtered_collection.fetch_page.assert_awaited_once_with(limit=0)
+
+
+async def test_exists_for_account_not_found(
+    installation_service_factory, installation_collection_factory, mocker
+):
+    service, installations_client = installation_service_factory()
+    page = installation_collection_factory(total=0)
+    filtered_collection = mocker.Mock(spec=["fetch_page"])
+    filtered_collection.fetch_page = mocker.AsyncMock(spec=Callable, return_value=page)
+    installations_client.filter = mocker.Mock(return_value=filtered_collection)
+
+    result = await service.exists_for_account(extension_id="EXT-1", account_id="ACC-1")
+
+    assert result is False
+
+
+async def test_exists_for_account_propagates_api_error(mocker, installation_service_factory):
+    service, installations_client = installation_service_factory()
+    filtered_collection = mocker.Mock(spec=["fetch_page"])
+    filtered_collection.fetch_page = mocker.AsyncMock(
+        spec=Callable, side_effect=RuntimeError("boom")
+    )
+    installations_client.filter = mocker.Mock(return_value=filtered_collection)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await service.exists_for_account(extension_id="EXT-1", account_id="ACC-1")


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

- Exposes `ctx.mpt_api_service.installations` backed by a new `InstallationService` over the integration installations endpoint.
- Implements `exists_for_account(extension_id, account_id) -> bool` using an RQL filter on `extension.id` and `account.id`. Returns `True` for any matching installation regardless of status; only an empty result set maps to `False`. Other API errors are propagated.
- Adds `Installation` and `InstallationReference` SDK models for the new service surface (re-exported from `mpt_extension_sdk.models`).
- Documents the lookup in `docs/sdk_usage/marketplace-services.md`.

Part of [MPT-21906](https://softwareone.atlassian.net/browse/MPT-21906).

## Test plan

- [x] `make check-all` — 330 passed
- [x] Tests cover the found, not-found, and propagated-error paths for `exists_for_account` plus the new `installations` attribute on `MPTAPIService`.

[MPT-21906]: https://softwareone.atlassian.net/browse/MPT-21906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21909](https://softwareone.atlassian.net/browse/MPT-21909)

- Add InstallationService surfaced as ctx.mpt_api_service.installations to call the integration installations endpoint
- Implement exists_for_account(extension_id, account_id) -> bool:
  - Uses an RQL filter on extension.id and account.id
  - Returns True if any matching installation exists (any status: Invited, Installed, Uninstalled, Expired)
  - Returns False only when the result set is empty
  - Propagates other API errors unchanged
- Introduce Installation, InstallationReference, and InstallationStatus models; re-export Installation and InstallationReference from mpt_extension_sdk.models
- Expose installations attribute on MPTAPIService
- Document lookup usage in docs/sdk_usage/marketplace-services.md
- Add tests (make check-all passed — 330 tests): cover found, not-found, and propagated-error paths for exists_for_account and presence of installations on MPTAPIService
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21909]: https://softwareone.atlassian.net/browse/MPT-21909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ