### PR TITLE
MPT-21907 revert account-id MPT API service factory

### DIFF
--- a/docs/sdk_usage/marketplace-services.md
+++ b/docs/sdk_usage/marketplace-services.md
@@ -20,21 +20,6 @@ The SDK builds the service from the request context:
   Marketplace token
 - the auth context is also carried as `ctx.auth` when the request provides one
 
-When a handler needs to call the MPT API as a different account than the
-caller (for example as the Operations account when reacting to a Client
-agreement event), build the service from the account id directly:
-
-```python
-from mpt_extension_sdk.services.mpt_api_service import MPTAPIService
-
-mpt_api_service = await MPTAPIService.from_account_id(base_url, account_id)
-```
-
-`from_account_id` reuses the same account-scoped token mechanism as
-`from_auth_context` and resolves the extension identity from runtime settings,
-so the resulting service refreshes its token per request like any other
-account-scoped service.
-
 ## Installations
 
 Use `ctx.mpt_api_service.installations` to look up extension installations

--- a/mpt_extension_sdk/services/mpt_api_service/account_scoped_client.py
+++ b/mpt_extension_sdk/services/mpt_api_service/account_scoped_client.py
@@ -6,6 +6,7 @@ from mpt_api_client.http.async_client import AsyncHTTPClient
 from mpt_api_client.http.query_options import QueryOptions
 from mpt_api_client.http.types import HeaderTypes, QueryParam, RequestFiles, Response
 
+from mpt_extension_sdk.api.auth import AuthContext
 from mpt_extension_sdk.models.account import AccountToken
 from mpt_extension_sdk.services.api_client_v2.mpt_api_client import AsyncMPTClient
 from mpt_extension_sdk.settings.runtime import RuntimeSettings
@@ -30,21 +31,19 @@ class AccountTokenProvider:
         self,
         *,
         runtime_settings: RuntimeSettings,
-        extension_id: str,
-        account_id: str,
+        auth: AuthContext,
         service_type: type["MPTAPIService"],
         min_remaining_validity_seconds: int = TOKEN_EXPIRY_LEEWAY_SECONDS,
     ) -> None:
         self._runtime_settings = runtime_settings
-        self._extension_id = extension_id
-        self._account_id = account_id
+        self._auth = auth
         self._service_type = service_type
         self._min_remaining_validity_seconds = min_remaining_validity_seconds
 
     @property
     def cache_key(self) -> AccountCacheKey:
         """Return the cache key for the current account."""
-        return self._extension_id, self._account_id
+        return self._auth.extension_id, self._auth.account.id
 
     @classmethod
     def clear_cache(cls) -> None:
@@ -74,7 +73,7 @@ class AccountTokenProvider:
             base_url=self._runtime_settings.mpt_api_base_url,
             api_token=self._runtime_settings.ext_api_key,
         )
-        return await mpt_api_service.account_token.create_token(self._account_id)
+        return await mpt_api_service.account_token.create_token(self._auth.account.id)
 
     def _is_token_valid(self, expires_at: dt.datetime) -> bool:
         expected_time = dt.datetime.now(dt.UTC).timestamp() + self._min_remaining_validity_seconds

--- a/mpt_extension_sdk/services/mpt_api_service/api_service.py
+++ b/mpt_extension_sdk/services/mpt_api_service/api_service.py
@@ -19,7 +19,7 @@ from mpt_extension_sdk.services.mpt_api_service.product import (
 from mpt_extension_sdk.services.mpt_api_service.subscription import SubscriptionService
 from mpt_extension_sdk.services.mpt_api_service.task import TaskService
 from mpt_extension_sdk.services.mpt_api_service.template import TemplateService
-from mpt_extension_sdk.settings.runtime import RuntimeSettings, get_runtime_settings
+from mpt_extension_sdk.settings.runtime import get_runtime_settings
 
 
 class MPTAPIService:  # noqa: WPS215, WPS230
@@ -47,32 +47,16 @@ class MPTAPIService:  # noqa: WPS215, WPS230
     async def from_auth_context(cls, base_url: str, auth: AuthContext) -> Self:
         """Create the service from the request authentication context."""
         runtime_settings = get_runtime_settings()
-        return cls._build_account_scoped(
+        client = AccountScopedAsyncMPTClient.from_token_provider(
             base_url=base_url,
-            runtime_settings=runtime_settings,
-            extension_id=auth.extension_id,
-            account_id=auth.account.id,
+            bootstrap_api_token=runtime_settings.ext_api_key,
+            token_provider=AccountTokenProvider(
+                runtime_settings=runtime_settings,
+                auth=auth,
+                service_type=cls,
+            ),
         )
-
-    @classmethod
-    async def from_account_id(cls, base_url: str, account_id: str) -> Self:
-        """Create the service authenticated against a specific account.
-
-        Used by handlers that need to call the MPT API as a specific account
-        (for example the Operations account) without a request authentication
-        context. The extension identity is resolved from runtime settings.
-
-        Args:
-            base_url: MPT API base URL.
-            account_id: Target Marketplace account id to authenticate as.
-        """
-        runtime_settings = get_runtime_settings()
-        return cls._build_account_scoped(
-            base_url=base_url,
-            runtime_settings=runtime_settings,
-            extension_id=runtime_settings.extension_id,
-            account_id=account_id,
-        )
+        return cls(client)
 
     @classmethod
     def from_config(cls, base_url: str, api_token: str) -> Self:
@@ -83,24 +67,3 @@ class MPTAPIService:  # noqa: WPS215, WPS230
             api_token: MPT API token.
         """
         return cls(build_mpt_client(base_url=base_url, api_token=api_token))
-
-    @classmethod
-    def _build_account_scoped(
-        cls,
-        *,
-        base_url: str,
-        runtime_settings: RuntimeSettings,
-        extension_id: str,
-        account_id: str,
-    ) -> Self:
-        client = AccountScopedAsyncMPTClient.from_token_provider(
-            base_url=base_url,
-            bootstrap_api_token=runtime_settings.ext_api_key,
-            token_provider=AccountTokenProvider(
-                runtime_settings=runtime_settings,
-                extension_id=extension_id,
-                account_id=account_id,
-                service_type=cls,
-            ),
-        )
-        return cls(client)

--- a/tests/services/mpt_api_service/test_account_scoped.py
+++ b/tests/services/mpt_api_service/test_account_scoped.py
@@ -4,6 +4,7 @@ import pytest
 from mpt_api_client.http.async_client import AsyncHTTPClient
 from mpt_api_client.http.types import Response
 
+from mpt_extension_sdk.api.auth import Account, AccountType, AuthContext
 from mpt_extension_sdk.models.account import AccountToken
 from mpt_extension_sdk.services.mpt_api_service.account_scoped_client import (
     AccountScopedAsyncHTTPClient,
@@ -31,6 +32,12 @@ def account_token_factory():
 def token_provider_factory(mocker, account_token_factory, runtime_settings):  # noqa: WPS210
     def factory(account_token: AccountToken | None = None):
         provider_token = account_token_factory() if account_token is None else account_token
+        auth = mocker.Mock(
+            spec=AuthContext,
+            token="request-token",
+            extension_id="EXT-1",
+            account=Account(id="ACC-1", type=AccountType.CLIENT),
+        )
         account_token = mocker.Mock(
             spec=["create_token"], create_token=mocker.AsyncMock(return_value=provider_token)
         )
@@ -39,10 +46,7 @@ def token_provider_factory(mocker, account_token_factory, runtime_settings):  # 
             spec=["account_token"], account_token=account_token
         )
         provider = AccountTokenProvider(
-            runtime_settings=runtime_settings,
-            extension_id="EXT-1",
-            account_id="ACC-1",
-            service_type=service_type,
+            runtime_settings=runtime_settings, auth=auth, service_type=service_type
         )
         return provider, service_type, account_token
 

--- a/tests/services/mpt_api_service/test_api_service.py
+++ b/tests/services/mpt_api_service/test_api_service.py
@@ -1,7 +1,6 @@
-import pytest
 from mpt_api_client import AsyncMPTClient
 
-from mpt_extension_sdk.api.auth import Account, AccountType, AuthContext
+from mpt_extension_sdk.api.auth import AuthContext
 from mpt_extension_sdk.services.mpt_api_service.api_service import MPTAPIService
 
 
@@ -39,12 +38,7 @@ def test_api_service_from_config(mocker):
 
 
 async def test_from_auth_context_uses_account_client(mocker, runtime_settings):  # noqa: WPS210
-    auth = AuthContext(
-        token="request-token",
-        account=Account(id="ACC-1", type=AccountType.CLIENT),
-        permissions={},
-        extension_id="EXT-1",
-    )
+    auth = mocker.Mock(spec=AuthContext)
     client = mocker.AsyncMock(spec=AsyncMPTClient)
     get_runtime_settings = mocker.patch(
         "mpt_extension_sdk.services.mpt_api_service.api_service.get_runtime_settings",
@@ -68,70 +62,10 @@ async def test_from_auth_context_uses_account_client(mocker, runtime_settings): 
     assert result.client is client
     get_runtime_settings.assert_called_once_with()
     token_provider.assert_called_once_with(
-        runtime_settings=runtime_settings,
-        extension_id="EXT-1",
-        account_id="ACC-1",
-        service_type=MPTAPIService,
+        runtime_settings=runtime_settings, auth=auth, service_type=MPTAPIService
     )
     from_token_provider.assert_called_once_with(
         base_url="https://api.example.com",
         bootstrap_api_token=runtime_settings.ext_api_key,
         token_provider=token_provider.return_value,
     )
-
-
-async def test_from_account_id_uses_runtime(mocker, runtime_settings):  # noqa: WPS210
-    client = mocker.AsyncMock(spec=AsyncMPTClient)
-    get_runtime_settings = mocker.patch(
-        "mpt_extension_sdk.services.mpt_api_service.api_service.get_runtime_settings",
-        autospec=True,
-        return_value=runtime_settings,
-    )
-    token_provider = mocker.patch(
-        "mpt_extension_sdk.services.mpt_api_service.api_service.AccountTokenProvider",
-        autospec=True,
-    )
-    from_token_provider = mocker.patch(
-        "mpt_extension_sdk.services.mpt_api_service.api_service."
-        "AccountScopedAsyncMPTClient.from_token_provider",
-        autospec=True,
-        return_value=client,
-    )
-
-    result = await MPTAPIService.from_account_id("https://api.example.com", "ACC-OPS")
-
-    assert isinstance(result, MPTAPIService)
-    assert result.client is client
-    get_runtime_settings.assert_called_once()
-    token_provider.assert_called_once_with(
-        runtime_settings=runtime_settings,
-        extension_id=runtime_settings.extension_id,
-        account_id="ACC-OPS",
-        service_type=MPTAPIService,
-    )
-    from_token_provider.assert_called_once_with(
-        base_url="https://api.example.com",
-        bootstrap_api_token=runtime_settings.ext_api_key,
-        token_provider=token_provider.return_value,
-    )
-
-
-async def test_from_account_id_propagates_errors(mocker, runtime_settings):
-    mocker.patch(
-        "mpt_extension_sdk.services.mpt_api_service.api_service.get_runtime_settings",
-        autospec=True,
-        return_value=runtime_settings,
-    )
-    mocker.patch(
-        "mpt_extension_sdk.services.mpt_api_service.api_service.AccountTokenProvider",
-        autospec=True,
-    )
-    mocker.patch(
-        "mpt_extension_sdk.services.mpt_api_service.api_service."
-        "AccountScopedAsyncMPTClient.from_token_provider",
-        autospec=True,
-        side_effect=RuntimeError("token boom"),
-    )
-
-    with pytest.raises(RuntimeError, match="token boom"):
-        await MPTAPIService.from_account_id("https://api.example.com", "ACC-OPS")


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## Summary

- Reverts PR #208, which added `MPTAPIService.from_account_id`.
- Restores the auth-context-based account token provider construction path.
- Removes tests and documentation for the account-id service factory while preserving later unrelated Installations documentation.

This PR is stacked on top of the revert for [#209](https://github.com/softwareone-platform/mpt-extension-sdk/pull/214), because #209 depends on `MPTAPIService.from_account_id` while it remains on `main`.

## Test plan

- [x] `make check-all` — 333 passed

Reverts [#208](https://github.com/softwareone-platform/mpt-extension-sdk/pull/208).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21907](https://softwareone.atlassian.net/browse/MPT-21907)

## Release Notes

- Reverts PR `#208`: removes MPTAPIService.from_account_id() factory and restores auth-context-based account token provider construction
- AccountTokenProvider now accepts an AuthContext (contains extension and account info) instead of separate extension_id and account_id parameters
- MPTAPIService._build_account_scoped() private helper removed; account-scoped client construction is inlined in from_auth_context()
- Documentation updated to remove guidance and examples for building the service directly from an account_id; retains unrelated Installations docs
- Tests updated to use AuthContext-based initialization; test suite: make check-all — 333 passed
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21907]: https://softwareone.atlassian.net/browse/MPT-21907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ