### PR TITLE
MPT-22054 mpt-extension-sdk documentation fixes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ The main package lives under [`mpt_extension_sdk/`](../mpt_extension_sdk).
 - [`pipeline/`](../mpt_extension_sdk/pipeline): execution contexts, context factory helpers, decorators, pipeline base classes, and steps
 - [`runtime/`](../mpt_extension_sdk/runtime): FastAPI app assembly, runtime startup, logging context, and platform bootstrap helpers
 - [`services/mpt_api_service/`](../mpt_extension_sdk/services/mpt_api_service): Marketplace service layer used by handlers, pipelines, and runtime operations
-- [`services/api_client_v2/`](../mpt_extension_sdk/services/api_client_v2): newer async Marketplace API client layer (`mpt_api_client`, `integration/`, `system/`), used alongside `mpt_api_service`
+- [`services/api_client_v2/`](../mpt_extension_sdk/services/api_client_v2): lower-level async Marketplace API client (`mpt_api_client.py` exposes `AsyncMPTClient`, with `integration/` and `system/` subpackages). `MPTAPIService` and its sub-services are constructed with the `AsyncMPTClient` from this layer, so `api_client_v2` is a dependency of `mpt_api_service` rather than a peer
 - [`settings/`](../mpt_extension_sdk/settings): runtime and extension settings discovery
 - [`observability/`](../mpt_extension_sdk/observability): tracing bootstrap, instrumentation, and SDK-level observability hooks
 - [`models/`](../mpt_extension_sdk/models): typed Marketplace domain models used across contexts and services

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,6 +34,7 @@ The main package lives under [`mpt_extension_sdk/`](../mpt_extension_sdk).
 - [`pipeline/`](../mpt_extension_sdk/pipeline): execution contexts, context factory helpers, decorators, pipeline base classes, and steps
 - [`runtime/`](../mpt_extension_sdk/runtime): FastAPI app assembly, runtime startup, logging context, and platform bootstrap helpers
 - [`services/mpt_api_service/`](../mpt_extension_sdk/services/mpt_api_service): Marketplace service layer used by handlers, pipelines, and runtime operations
+- [`services/api_client_v2/`](../mpt_extension_sdk/services/api_client_v2): newer async Marketplace API client layer (`mpt_api_client`, `integration/`, `system/`), used alongside `mpt_api_service`
 - [`settings/`](../mpt_extension_sdk/settings): runtime and extension settings discovery
 - [`observability/`](../mpt_extension_sdk/observability): tracing bootstrap, instrumentation, and SDK-level observability hooks
 - [`models/`](../mpt_extension_sdk/models): typed Marketplace domain models used across contexts and services

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,6 @@ The SDK runtime relies on these settings:
 | `SDK_OBSERVABILITY_ENABLED` | `true` | `false` | Enables SDK observability bootstrap |
 | `SDK_APPLICATIONINSIGHTS_CONNECTION_STRING` | - | `InstrumentationKey=...` | Azure Monitor connection string used by the SDK observability bootstrap |
 | `SDK_OTEL_SERVICE_NAME` | - | `my-extension` | Optional OpenTelemetry service name override |
-| `SDK_OTEL_EXPORTERS` | SDK default | `otlp` | Demo/runtime exporter selection for the SDK observability bootstrap |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | exporter default | `http://jaeger:4318` | OTLP collector endpoint used when OTLP export is enabled |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | exporter default | `http/protobuf` | OTLP protocol for the configured exporter |
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -22,7 +22,7 @@ The default development model for this repository is Docker-based.
 
 - Use `make build` to build the local image and install dependencies.
 - Use `make run` to start the local runtime through Docker Compose.
-- Use `make bash` or `make shell` when you need an interactive container session.
+- Use `make bash` when you need an interactive container session.
 - Use `make build-package` when you need to produce a distributable package artifact inside the configured runtime.
 
 ## Code Organization Expectations

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -38,7 +38,6 @@ make test
 make build
 make run
 make bash
-make shell
 make format
 make check
 make test

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -48,7 +48,6 @@ Shared make-target knowledge also applies in this repository:
 - `make test`: run the automated test suite
 - `make check-all`: run the full local validation flow expected before merge
 - `make bash`: open a shell in the application container or runtime environment
-- `make shell`: open an application-specific shell
 
 ## Pytest Configuration
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What
Documentation fixes for mpt-extension-sdk (MPT-22054, under MPT-22048).

- **docs/architecture.md**: document `services/api_client_v2/` (the newer async Marketplace API client — `mpt_api_client`, `integration/`, `system/`) in the package layout; previously undocumented.
- **docs/configuration.md**: remove `SDK_OTEL_EXPORTERS`. The SDK observability bootstrap reads `SDK_OTEL_SERVICE_NAME` / `SDK_OBSERVABILITY_ENABLED` (`runtime/logging.py`, `settings/runtime.py`); `SDK_OTEL_EXPORTERS` is not consumed by runtime code (only present in `.env.demo`).
- **make shell → make bash** in testing.md, local-development.md, and contributing.md (only `make bash` exists).

## Note on empty placeholder dirs
The `tests/{key_vault,airtable,flows,mpt_http,swo_rql}` directories flagged in the audit are **not tracked in git** (local-only artifacts), so there is nothing to clean up or document in the repository.

## Testing
- `audit_docs.py`: no missing required docs, no recommendations.
- pre-commit file-hygiene hooks pass.

Subtask: MPT-22054 (parent MPT-22048).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-22054](https://softwareone.atlassian.net/browse/MPT-22054)

- Documented mpt_extension_sdk/services/api_client_v2 in docs/architecture.md as the lower-level async Marketplace API client (AsyncMPTClient) and noted its integration/ and system/ subpackages and that it is a dependency for MPTAPIService.
- Removed SDK_OTEL_EXPORTERS from the Core Environment Variables table in docs/configuration.md (it's not consumed by runtime code; runtime uses SDK_OTEL_SERVICE_NAME and SDK_OBSERVABILITY_ENABLED).
- Replaced references to make shell with make bash in docs/contributing.md, docs/local-development.md, and docs/testing.md.
- Clarified that tests/{key_vault,airtable,flows,mpt_http,swo_rql} are local-only (not tracked in git), so no repo cleanup or further documentation changes are required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22054]: https://softwareone.atlassian.net/browse/MPT-22054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ