### PR TITLE
MPT-22386 Add Danger PR-formatting check workflow

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,24 @@
+name: Danger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  danger:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Danger
+        uses: softwareone-platform/one-danger@1.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Add `.github/workflows/danger.yml` running the shared `softwareone-platform/one-danger@1.1.0` action on pull requests. It enforces the PR-formatting rules (Jira key in title, single commit, size threshold, no merge commits, release-branch markers and release→main linkage) via Danger.

This is the smoke-test repository for the org-wide rollout (US-3); the same workflow will be added to the other repositories.

## Jira

Closes MPT-22386 (subtask of MPT-22376).

## Testing

This PR triggers the new Danger workflow on itself.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-22386](https://softwareone.atlassian.net/browse/MPT-22386)

- Added GitHub Actions workflow (`.github/workflows/danger.yml`) to integrate Danger CI for PR formatting validation
- Workflow enforces PR-formatting rules including Jira key presence, single commit requirement, size thresholds, no merge commits, release-branch markers, and release-to-main branch linkage verification
- Executes on `pull_request` events (`opened`, `synchronize`, `reopened`, `edited`) using the shared `softwareone-platform/one-danger@1.1.0` action
- Repository serves as smoke-test for organization-wide rollout of standardized Danger workflow across SoftwareOne Platform repositories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22386]: https://softwareone.atlassian.net/browse/MPT-22386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ