### PR TITLE
docs: pure-.NET extension SDK — design spec + implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-06-19-dotnet-sdk-plan1-foundation-and-native-hosting.md
+++ b/docs/superpowers/plans/2026-06-19-dotnet-sdk-plan1-foundation-and-native-hosting.md
@@ -1,0 +1,2166 @@
+# Pure-.NET Extension SDK — Plan 1: Foundation + Native Hosting
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bootstrap a pure-.NET (net8.0) Marketplace extension SDK in the empty directory `C:\repos\mpt-extension-sdk-dotnet`, porting the existing C# authoring surface and replacing the Python bridge's registration + ingress-auth + egress responsibilities with native .NET — producing a fully working **local-mode** extension host (no Ziti yet).
+
+**Architecture:** Port the proven authoring code (attributes, contexts, dispatch, discovery, manifest, source generator) from the canonical repo `C:\repos\mpt-extension-dotnet-sdk` into a fresh solution, retargeted to net8.0. Then rewire the host pipeline: parse the real `Authorization: Bearer` JWT instead of the bridge's `X-Mpt-Auth` header, and replace the bridge egress proxy with a direct, account-scoped Marketplace `HttpClient` that mints/caches/refreshes account tokens. Registration runs as an `IHostedService`. The SDK stays model-agnostic — `IMarketplaceClient` is generic and serialization options are injectable.
+
+**Tech Stack:** .NET 8 (ASP.NET Core minimal APIs, `IHostedService`, `IHttpClientFactory`), System.Text.Json, xUnit + `Microsoft.AspNetCore.Mvc.Testing` (`TestServer`), Roslyn source generator (netstandard2.0).
+
+**Scope boundaries (deferred to later plans):**
+- **Plan 2:** OpenZiti transport (the `OpenZiti.NET` Kestrel binding) + the Abstractions/Ziti package split. Plan 1 ships a single `Mpt.Extensions.Sdk` package; the package split exists to isolate the native Ziti dependency, so it is premature before Plan 2 (YAGNI).
+- **Plan 3:** Porting `product-hub-extension` onto the pure-.NET SDK as the acceptance check.
+
+**Source-of-truth for ports:** `C:\repos\mpt-extension-dotnet-sdk` (read-only; do not modify it). Referred to below as `$SRC`. The new work directory `C:\repos\mpt-extension-sdk-dotnet` is referred to as `$DST`.
+
+---
+
+## File structure (end state of Plan 1)
+
+```
+$DST/
+  Mpt.Extensions.Sdk.slnx
+  Directory.Build.props                 # net8.0, shared metadata
+  nuget.config                          # nuget.org + PyraCloud (for consumers; SDK itself needs neither)
+  .gitignore
+  src/
+    Mpt.Extensions.Sdk/                  # the one SDK package (authoring + native hosting)
+      Attributes/ Contexts/ Events/ Manifest/ Dispatch/ Discovery/ Generated/   # ported as-is
+      Marketplace/
+        IMarketplaceClient.cs            # ported (generic; unchanged)
+        MarketplaceApiException.cs       # ported (unchanged)
+        HttpMarketplaceClient.cs         # NEW — direct account-scoped MPT API client
+      Auth/
+        AuthContext.cs                   # ported + enriched (permissions/claims)
+        SoftwareOneJwt.cs                # NEW — decode-not-verify JWT claims
+        RequestAuthenticator.cs          # NEW — Bearer → AuthContext (+ exp check)
+        IAccountTokenProvider.cs         # NEW
+        AccountTokenProvider.cs          # NEW — mint/cache/refresh per-account token
+      Hosting/
+        ExtensionHostBuilder.cs          # ported + rewired (native auth/client, registration)
+        ExtensionEndpoints.cs            # ported + rewired (real JWT, no bridge token/egress header)
+        ExtensionOptions.cs              # NEW — typed runtime options (replaces HostOptions)
+      Registration/
+        IdentityStore.cs                 # NEW — read/write identity file
+        RegistrationPayload.cs           # NEW — request/response DTOs + meta block
+        RegistrationService.cs           # NEW — POST instances, persist identity
+        RegistrationHostedService.cs     # NEW — runs registration on startup (platform mode)
+        MetaBuilder.cs                   # NEW — ExtensionManifest → meta object (+ meta.yaml)
+      Serialization/MptJson.cs           # ported + made configurable
+    Mpt.Extensions.Sdk.SourceGen/        # ported as-is (netstandard2.0)
+  tests/
+    Mpt.Extensions.Sdk.Tests/            # ported core tests + new tests, rewired for native auth
+    Mpt.Extensions.Sdk.SourceGen.Tests/  # ported as-is
+```
+
+---
+
+## Phase A — Bootstrap the solution
+
+### Task A1: Initialise the repository and solution skeleton
+
+**Files:**
+- Create: `$DST/.gitignore`
+- Create: `$DST/Directory.Build.props`
+- Create: `$DST/nuget.config`
+- Create: `$DST/Mpt.Extensions.Sdk.slnx`
+
+- [ ] **Step 1: Initialise git in the empty work dir**
+
+Run:
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet' && git init -b main && echo done
+```
+Expected: `Initialized empty Git repository …` then `done`.
+
+- [ ] **Step 2: Create `.gitignore`**
+
+Create `$DST/.gitignore`:
+```gitignore
+bin/
+obj/
+*.user
+.vs/
+identity/
+*.identity.json
+artifacts/
+```
+
+- [ ] **Step 3: Create `Directory.Build.props` (net8.0)**
+
+Create `$DST/Directory.Build.props`:
+```xml
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <Authors>SoftwareOne</Authors>
+    <Company>SoftwareOne</Company>
+    <Copyright>SoftwareOne © 2026</Copyright>
+    <Version>0.1.0-alpha.1</Version>
+    <IsPackable>false</IsPackable>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+  </PropertyGroup>
+</Project>
+```
+
+- [ ] **Step 4: Create `nuget.config`**
+
+Create `$DST/nuget.config` (PyraCloud is for downstream extensions that reference platform contracts; the SDK itself needs only nuget.org):
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="PyraCloud" value="https://pkgs.dev.azure.com/softwareone-pc/_packaging/PyraCloud/nuget/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+- [ ] **Step 5: Create the solution file**
+
+Create `$DST/Mpt.Extensions.Sdk.slnx`:
+```xml
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/Mpt.Extensions.Sdk/Mpt.Extensions.Sdk.csproj" />
+    <Project Path="src/Mpt.Extensions.Sdk.SourceGen/Mpt.Extensions.Sdk.SourceGen.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Mpt.Extensions.Sdk.Tests/Mpt.Extensions.Sdk.Tests.csproj" />
+    <Project Path="tests/Mpt.Extensions.Sdk.SourceGen.Tests/Mpt.Extensions.Sdk.SourceGen.Tests.csproj" />
+  </Folder>
+</Solution>
+```
+
+- [ ] **Step 6: Verify .NET 8 SDK is available**
+
+Run:
+```bash
+dotnet --list-sdks
+```
+Expected: at least one `8.0.x` SDK listed. If only net10 is installed, install the .NET 8 SDK before continuing (or add a `global.json` pinning 8.0).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+git add -A
+git commit -m "chore: bootstrap solution skeleton (net8.0)"
+```
+
+---
+
+### Task A2: Copy the design docs into the new repo
+
+**Files:**
+- Create: `$DST/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md`
+- Create: `$DST/docs/superpowers/plans/2026-06-19-dotnet-sdk-plan1-foundation-and-native-hosting.md`
+
+- [ ] **Step 1: Copy spec and plan so they travel with the code**
+
+Run (paths are the current worktree of the Python repo where these docs live):
+```bash
+mkdir -p 'C:/repos/mpt-extension-sdk-dotnet/docs/superpowers/specs' 'C:/repos/mpt-extension-sdk-dotnet/docs/superpowers/plans'
+cp 'C:/repos/mpt-extension-sdk/.claude/worktrees/heuristic-leakey-ff4ebd/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md' 'C:/repos/mpt-extension-sdk-dotnet/docs/superpowers/specs/'
+cp 'C:/repos/mpt-extension-sdk/.claude/worktrees/heuristic-leakey-ff4ebd/docs/superpowers/plans/2026-06-19-dotnet-sdk-plan1-foundation-and-native-hosting.md' 'C:/repos/mpt-extension-sdk-dotnet/docs/superpowers/plans/'
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+git add -A
+git commit -m "docs: import design spec and Plan 1"
+```
+
+---
+
+## Phase B — Port the authoring surface (verbatim, net8.0)
+
+> These files are already model-agnostic and net-version-neutral. Copy them as-is; do not edit namespaces (we keep the `Mpt.Extensions.Sdk` root). After copying, build to surface any net10-only API usage (Risk: net10→net8 retarget).
+
+### Task B1: Port the source generator project
+
+**Files:**
+- Create: `$DST/src/Mpt.Extensions.Sdk.SourceGen/` (copy of `$SRC/src/Mpt.Extensions.Sdk.SourceGen/`)
+
+- [ ] **Step 1: Copy the source-generator project**
+
+```bash
+mkdir -p 'C:/repos/mpt-extension-sdk-dotnet/src'
+cp -r 'C:/repos/mpt-extension-dotnet-sdk/src/Mpt.Extensions.Sdk.SourceGen' 'C:/repos/mpt-extension-sdk-dotnet/src/'
+rm -rf 'C:/repos/mpt-extension-sdk-dotnet/src/Mpt.Extensions.Sdk.SourceGen/bin' 'C:/repos/mpt-extension-sdk-dotnet/src/Mpt.Extensions.Sdk.SourceGen/obj'
+```
+
+- [ ] **Step 2: Confirm it targets netstandard2.0 (analyzers must)**
+
+Read `$DST/src/Mpt.Extensions.Sdk.SourceGen/Mpt.Extensions.Sdk.SourceGen.csproj`.
+Expected: `<TargetFramework>netstandard2.0</TargetFramework>` is set **explicitly inside the csproj** (so the repo-wide net8.0 default does not apply). If the csproj relies on the old `Directory.Build.props` net10 inheritance and has no explicit TFM, add `<TargetFramework>netstandard2.0</TargetFramework>` to its first `<PropertyGroup>`, and add `<TreatWarningsAsErrors>false</TreatWarningsAsErrors>` only if the generator emits analyzer-package warnings.
+
+- [ ] **Step 3: Build just the generator**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+dotnet build src/Mpt.Extensions.Sdk.SourceGen/Mpt.Extensions.Sdk.SourceGen.csproj
+```
+Expected: `Build succeeded`. Fix any netstandard2.0 incompatibilities surfaced.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "feat: port source generator project"
+```
+
+### Task B2: Port the authoring code into the core SDK project
+
+**Files:**
+- Create: `$DST/src/Mpt.Extensions.Sdk/` with the subfolders `Attributes/`, `Contexts/`, `Events/`, `Manifest/`, `Dispatch/`, `Discovery/`, `Generated/`, `Marketplace/`, `Auth/`, `Serialization/`
+- Create: `$DST/src/Mpt.Extensions.Sdk/Mpt.Extensions.Sdk.csproj`
+
+- [ ] **Step 1: Copy the authoring source folders (NOT Hosting yet — that gets rewired in Phase D)**
+
+```bash
+SRC='C:/repos/mpt-extension-dotnet-sdk/src/Mpt.Extensions.Sdk'
+DST='C:/repos/mpt-extension-sdk-dotnet/src/Mpt.Extensions.Sdk'
+mkdir -p "$DST"
+for d in Attributes Contexts Events Manifest Dispatch Discovery Generated Marketplace Auth Serialization; do
+  cp -r "$SRC/$d" "$DST/"
+done
+```
+
+- [ ] **Step 2: Remove the egress-only Marketplace files (replaced by native client in Phase D)**
+
+```bash
+DST='C:/repos/mpt-extension-sdk-dotnet/src/Mpt.Extensions.Sdk'
+rm -f "$DST/Marketplace/EgressMarketplaceClient.cs" "$DST/Marketplace/MarketplaceRequest.cs"
+```
+(We keep `IMarketplaceClient.cs` and `MarketplaceApiException.cs`.)
+
+- [ ] **Step 3: Create the core csproj (net8.0; no bridge analyzer error target needed yet, keep the analyzer bundling)**
+
+Create `$DST/src/Mpt.Extensions.Sdk/Mpt.Extensions.Sdk.csproj`:
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+
+    <IsPackable>true</IsPackable>
+    <PackageId>Mpt.Extensions.Sdk</PackageId>
+    <Title>MPT Extension SDK for .NET</Title>
+    <Description>Author SoftwareONE Marketplace extensions in C#. Pure-.NET host: native registration, OpenZiti transport, and account-scoped Marketplace access. Includes the bundled Roslyn source generator.</Description>
+    <PackageTags>mpt;marketplace;softwareone;extensions;sdk</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Mpt.Extensions.Sdk.Tests" />
+    <InternalsVisibleTo Include="Mpt.Extensions.Sdk.SourceGen.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mpt.Extensions.Sdk.SourceGen\Mpt.Extensions.Sdk.SourceGen.csproj"
+                      OutputItemType="Analyzer" ReferenceOutputAssembly="false" PrivateAssets="all" />
+  </ItemGroup>
+  <PropertyGroup>
+    <_SourceGenDll>..\Mpt.Extensions.Sdk.SourceGen\bin\$(Configuration)\netstandard2.0\Mpt.Extensions.Sdk.SourceGen.dll</_SourceGenDll>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="$(_SourceGenDll)" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+  <Target Name="EnsureAnalyzerBundled" BeforeTargets="GenerateNuspec">
+    <Error Condition="!Exists('$(_SourceGenDll)')"
+           Text="Source generator not found at $(_SourceGenDll). Build the solution in this configuration before packing so the analyzer is bundled." />
+  </Target>
+</Project>
+```
+
+- [ ] **Step 4: Temporarily exclude Hosting so the project builds without it**
+
+The copied folders do **not** include `Hosting/`, so the core project has no `ExtensionHostBuilder` yet. That is expected — Phase D adds Hosting. The project should still compile (authoring types only).
+
+Run:
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+dotnet build src/Mpt.Extensions.Sdk/Mpt.Extensions.Sdk.csproj
+```
+Expected: `Build succeeded`. If any file references `Hosting`/`MptJson`/egress types that were removed, note them — they belong to Phase D and should not be in the copied folders. If `Serialization/MptJson.cs` is referenced by dispatch, keep it (it was copied).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat: port authoring surface (attributes, contexts, dispatch, manifest, discovery)"
+```
+
+### Task B3: Port the test projects and get the ported tests green
+
+**Files:**
+- Create: `$DST/tests/Mpt.Extensions.Sdk.Tests/` (port; minus egress/marketplace-model tests)
+- Create: `$DST/tests/Mpt.Extensions.Sdk.SourceGen.Tests/` (port as-is)
+
+- [ ] **Step 1: Copy both test projects**
+
+```bash
+SRC='C:/repos/mpt-extension-dotnet-sdk/tests'
+DST='C:/repos/mpt-extension-sdk-dotnet/tests'
+mkdir -p "$DST"
+cp -r "$SRC/Mpt.Extensions.Sdk.Tests" "$DST/"
+cp -r "$SRC/Mpt.Extensions.Sdk.SourceGen.Tests" "$DST/"
+find "$DST" -type d \( -name bin -o -name obj \) -prune -exec rm -rf {} +
+```
+
+- [ ] **Step 2: Remove tests that depend on dropped pieces (egress client, generated Marketplace models)**
+
+```bash
+DST='C:/repos/mpt-extension-sdk-dotnet/tests/Mpt.Extensions.Sdk.Tests'
+rm -f "$DST/EgressMarketplaceClientTests.cs" "$DST/MarketplaceClientTests.cs"
+```
+(`MarketplaceClientTests` exercised the generated-models `MarketplaceClient`, which we are not porting. `EgressMarketplaceClientTests` tested the bridge egress client, now removed. `HostIntegrationTests` is kept but rewired in Phase D.)
+
+- [ ] **Step 3: Fix the test csproj (remove the Marketplace-models project reference; net8.0 test stack)**
+
+Overwrite `$DST/tests/Mpt.Extensions.Sdk.Tests/Mpt.Extensions.Sdk.Tests.csproj`:
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.11" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mpt.Extensions.Sdk\Mpt.Extensions.Sdk.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+- [ ] **Step 4: Fix the SourceGen tests csproj the same way (net8.0 test stack, keep its existing project references)**
+
+Open `$DST/tests/Mpt.Extensions.Sdk.SourceGen.Tests/Mpt.Extensions.Sdk.SourceGen.Tests.csproj` and set the same package versions as Step 3 (`Microsoft.NET.Test.Sdk` 17.12.0, `xunit` 2.9.2, `xunit.runner.visualstudio` 3.0.0, `Microsoft.AspNetCore.Mvc.Testing` 8.0.11 if referenced). Keep its `ProjectReference`s to the SDK and SourceGen projects. Remove any reference to `Mpt.Extensions.Sdk.Marketplace`.
+
+- [ ] **Step 5: Move HostIntegrationTests aside until Phase D adds Hosting**
+
+`HostIntegrationTests.cs` references `ExtensionHostBuilder` (added in Phase D). Rename it so it does not break the Phase B build:
+```bash
+DST='C:/repos/mpt-extension-sdk-dotnet/tests/Mpt.Extensions.Sdk.Tests'
+mv "$DST/HostIntegrationTests.cs" "$DST/HostIntegrationTests.cs.pending"
+```
+(Phase D Task D6 restores and rewires it.)
+
+- [ ] **Step 6: Build and run the ported tests**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+dotnet test
+```
+Expected: solution builds; the ported attribute/dispatch/manifest/discovery/event/auth/source-gen tests **pass**. Fix any net10→net8 issues that surface (e.g., trimmed APIs, `System.Text.Json` version differences). Do not proceed until green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "test: port authoring + source-gen tests (net8.0), green"
+```
+
+---
+
+## Phase C — Make serialization configurable
+
+### Task C1: Replace the static `MptJson` with an injectable options holder
+
+**Files:**
+- Modify: `$DST/src/Mpt.Extensions.Sdk/Serialization/MptJson.cs`
+- Test: `$DST/tests/Mpt.Extensions.Sdk.Tests/MptJsonTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `$DST/tests/Mpt.Extensions.Sdk.Tests/MptJsonTests.cs`:
+```csharp
+using System.Text.Json;
+using Mpt.Extensions.Sdk.Serialization;
+
+namespace Mpt.Extensions.Sdk.Tests;
+
+public class MptJsonTests
+{
+    [Fact]
+    public void Default_options_are_web_camelCase_and_case_insensitive()
+    {
+        Assert.Equal(JsonNamingPolicy.CamelCase, MptJson.Default.PropertyNamingPolicy);
+        Assert.True(MptJson.Default.PropertyNameCaseInsensitive);
+    }
+
+    [Fact]
+    public void CreateDefault_returns_an_independent_mutable_copy()
+    {
+        var a = MptJson.CreateDefault();
+        var b = MptJson.CreateDefault();
+        a.Converters.Add(new JsonStringEnumConverter());
+        Assert.NotSame(a, b);
+        Assert.Empty(b.Converters); // mutating one copy does not affect another
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+dotnet test --filter FullyQualifiedName~MptJsonTests
+```
+Expected: FAIL — `MptJson.Default` / `MptJson.CreateDefault` do not exist.
+
+- [ ] **Step 3: Implement**
+
+Overwrite `$DST/src/Mpt.Extensions.Sdk/Serialization/MptJson.cs`:
+```csharp
+using System.Text.Json;
+
+namespace Mpt.Extensions.Sdk.Serialization;
+
+/// <summary>
+/// Shared JSON configuration. <see cref="Default"/> is the read-only options the host wire
+/// uses (event envelope, manifest, responses). Extensions that deserialize platform contracts
+/// supply their own options via <see cref="CreateDefault"/> + their converters.
+/// </summary>
+public static class MptJson
+{
+    /// <summary>Web defaults: camelCase, case-insensitive. Do not mutate.</summary>
+    public static readonly JsonSerializerOptions Default = CreateDefault();
+
+    /// <summary>A fresh, mutable options instance with the SDK's web defaults.</summary>
+    public static JsonSerializerOptions CreateDefault() => new(JsonSerializerDefaults.Web);
+}
+```
+
+- [ ] **Step 4: Run the test — expect pass**
+
+```bash
+dotnet test --filter FullyQualifiedName~MptJsonTests
+```
+Expected: PASS.
+
+- [ ] **Step 5: Update internal references from `MptJson.Options` to `MptJson.Default`**
+
+Search the core project for `MptJson.Options` and replace with `MptJson.Default`:
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+grep -rl 'MptJson.Options' src tests || echo "none"
+```
+For each hit, change `MptJson.Options` → `MptJson.Default`. Then:
+```bash
+dotnet build
+```
+Expected: `Build succeeded`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat: make MptJson serialization options configurable"
+```
+
+---
+
+## Phase D — Native hosting (auth, account tokens, Marketplace client, registration)
+
+> This phase replaces everything the Python bridge did. Build it on **plain Kestrel** — no Ziti. By the end, an extension runs locally end-to-end with real JWT auth and direct MPT API calls.
+
+### Task D1: Decode-not-verify SoftwareONE JWT claims
+
+**Files:**
+- Create: `$DST/src/Mpt.Extensions.Sdk/Auth/SoftwareOneJwt.cs`
+- Test: `$DST/tests/Mpt.Extensions.Sdk.Tests/SoftwareOneJwtTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `$DST/tests/Mpt.Extensions.Sdk.Tests/SoftwareOneJwtTests.cs`:
+```csharp
+using System.Text;
+using System.Text.Json;
+using Mpt.Extensions.Sdk.Auth;
+
+namespace Mpt.Extensions.Sdk.Tests;
+
+public class SoftwareOneJwtTests
+{
+    // Builds an unsigned-looking JWT: header.payload.signature (signature ignored).
+    private static string MakeToken(object payload)
+    {
+        static string B64Url(byte[] b) =>
+            Convert.ToBase64String(b).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        var header = B64Url(Encoding.UTF8.GetBytes("{\"alg\":\"none\",\"typ\":\"JWT\"}"));
+        var body = B64Url(JsonSerializer.SerializeToUtf8Bytes(payload));
+        return $"{header}.{body}.sig";
+    }
+
+    [Fact]
+    public void ParseClaims_reads_softwareone_namespaced_claims_and_exp()
+    {
+        var exp = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeSeconds();
+        var token = MakeToken(new Dictionary<string, object>
+        {
+            ["https://claims.softwareone.com/accountId"] = "ACC-1",
+            ["https://claims.softwareone.com/accountType"] = "Client",
+            ["https://claims.softwareone.com/extensionId"] = "EXT-9",
+            ["exp"] = exp,
+        });
+
+        var claims = SoftwareOneJwt.ParseClaims(token);
+
+        Assert.Equal("ACC-1", claims.AccountId);
+        Assert.Equal("Client", claims.AccountType);
+        Assert.Equal("EXT-9", claims.ExtensionId);
+        Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(exp), claims.ExpiresAt);
+    }
+
+    [Fact]
+    public void ParseClaims_throws_on_malformed_token()
+    {
+        Assert.Throws<FormatException>(() => SoftwareOneJwt.ParseClaims("not-a-jwt"));
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+```bash
+dotnet test --filter FullyQualifiedName~SoftwareOneJwtTests
+```
+Expected: FAIL — `SoftwareOneJwt` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `$DST/src/Mpt.Extensions.Sdk/Auth/SoftwareOneJwt.cs`:
+```csharp
+using System.Text.Json;
+
+namespace Mpt.Extensions.Sdk.Auth;
+
+/// <summary>Parsed SoftwareONE JWT claims. Signature is NOT verified — the platform gateway
+/// verifies upstream; the host only decodes to build request context.</summary>
+public sealed record SoftwareOneClaims(
+    string AccountId,
+    string? AccountType,
+    string? ExtensionId,
+    DateTimeOffset? ExpiresAt);
+
+/// <summary>Decodes (does not verify) SoftwareONE platform JWTs.</summary>
+public static class SoftwareOneJwt
+{
+    private const string Prefix = "https://claims.softwareone.com/";
+
+    public static SoftwareOneClaims ParseClaims(string token)
+    {
+        var parts = token.Split('.');
+        if (parts.Length < 2)
+            throw new FormatException("Token is not a well-formed JWT (expected 3 segments).");
+
+        using var doc = JsonDocument.Parse(DecodeSegment(parts[1]));
+        var root = doc.RootElement;
+
+        string GetString(string name) =>
+            root.TryGetProperty(name, out var v) ? v.GetString() ?? "" : "";
+
+        DateTimeOffset? exp = root.TryGetProperty("exp", out var e) && e.TryGetInt64(out var s)
+            ? DateTimeOffset.FromUnixTimeSeconds(s)
+            : null;
+
+        var accountId = GetString(Prefix + "accountId");
+        var accountType = GetString(Prefix + "accountType");
+        var extensionId = GetString(Prefix + "extensionId");
+
+        return new SoftwareOneClaims(
+            accountId,
+            string.IsNullOrEmpty(accountType) ? null : accountType,
+            string.IsNullOrEmpty(extensionId) ? null : extensionId,
+            exp);
+    }
+
+    private static byte[] DecodeSegment(string segment)
+    {
+        var s = segment.Replace('-', '+').Replace('_', '/');
+        s = (s.Length % 4) switch { 2 => s + "==", 3 => s + "=", _ => s };
+        return Convert.FromBase64String(s);
+    }
+}
+```
+
+- [ ] **Step 4: Run the test — expect pass**
+
+```bash
+dotnet test --filter FullyQualifiedName~SoftwareOneJwtTests
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat: decode-not-verify SoftwareONE JWT claims"
+```
+
+### Task D2: Enrich `AuthContext` and add the request authenticator
+
+**Files:**
+- Modify: `$DST/src/Mpt.Extensions.Sdk/Auth/AuthContext.cs`
+- Create: `$DST/src/Mpt.Extensions.Sdk/Auth/RequestAuthenticator.cs`
+- Test: `$DST/tests/Mpt.Extensions.Sdk.Tests/RequestAuthenticatorTests.cs`
+
+- [ ] **Step 1: Add a `Token` property to `AuthContext`**
+
+Edit `$DST/src/Mpt.Extensions.Sdk/Auth/AuthContext.cs` — add (the account-scoped Marketplace client needs the raw bearer token's account id; we also carry the original token for diagnostics):
+```csharp
+    [JsonPropertyName("token")]
+    public string? Token { get; init; }
+```
+Add it inside the existing `AuthContext` class alongside the other properties. Do not remove existing properties (`AccountId`, `AccountType`, `ExtensionId`, `InstallationId`, `UserId`).
+
+- [ ] **Step 2: Write the failing test**
+
+Create `$DST/tests/Mpt.Extensions.Sdk.Tests/RequestAuthenticatorTests.cs`:
+```csharp
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Mpt.Extensions.Sdk.Auth;
+
+namespace Mpt.Extensions.Sdk.Tests;
+
+public class RequestAuthenticatorTests
+{
+    private static string MakeToken(object payload)
+    {
+        static string B64Url(byte[] b) =>
+            Convert.ToBase64String(b).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        var header = B64Url(Encoding.UTF8.GetBytes("{\"alg\":\"none\"}"));
+        return $"{header}.{B64Url(JsonSerializer.SerializeToUtf8Bytes(payload))}.sig";
+    }
+
+    private static HttpContext WithBearer(string token)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Headers.Authorization = $"Bearer {token}";
+        return ctx;
+    }
+
+    [Fact]
+    public void Authenticate_builds_context_from_valid_token()
+    {
+        var token = MakeToken(new Dictionary<string, object>
+        {
+            ["https://claims.softwareone.com/accountId"] = "ACC-1",
+            ["https://claims.softwareone.com/accountType"] = "Client",
+            ["exp"] = DateTimeOffset.UtcNow.AddMinutes(5).ToUnixTimeSeconds(),
+        });
+
+        var auth = new RequestAuthenticator().Authenticate(WithBearer(token));
+
+        Assert.Equal("ACC-1", auth.AccountId);
+        Assert.Equal("Client", auth.AccountType);
+        Assert.Equal(token, auth.Token);
+    }
+
+    [Fact]
+    public void Authenticate_throws_when_no_authorization_header()
+    {
+        Assert.Throws<UnauthorizedAccessException>(
+            () => new RequestAuthenticator().Authenticate(new DefaultHttpContext()));
+    }
+
+    [Fact]
+    public void Authenticate_throws_when_token_expired()
+    {
+        var token = MakeToken(new Dictionary<string, object>
+        {
+            ["https://claims.softwareone.com/accountId"] = "ACC-1",
+            ["exp"] = DateTimeOffset.UtcNow.AddSeconds(-120).ToUnixTimeSeconds(),
+        });
+        Assert.Throws<UnauthorizedAccessException>(
+            () => new RequestAuthenticator().Authenticate(WithBearer(token)));
+    }
+}
+```
+
+- [ ] **Step 2b: Run it — expect failure**
+
+```bash
+dotnet test --filter FullyQualifiedName~RequestAuthenticatorTests
+```
+Expected: FAIL — `RequestAuthenticator` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `$DST/src/Mpt.Extensions.Sdk/Auth/RequestAuthenticator.cs`:
+```csharp
+using Microsoft.AspNetCore.Http;
+
+namespace Mpt.Extensions.Sdk.Auth;
+
+/// <summary>Builds an <see cref="AuthContext"/> from the platform's Bearer JWT.</summary>
+public sealed class RequestAuthenticator
+{
+    private static readonly TimeSpan ExpiryLeeway = TimeSpan.FromSeconds(30);
+
+    public AuthContext Authenticate(HttpContext http)
+    {
+        var header = http.Request.Headers.Authorization.ToString();
+        if (string.IsNullOrEmpty(header) || !header.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            throw new UnauthorizedAccessException("Missing or malformed Authorization header.");
+
+        var token = header["Bearer ".Length..].Trim();
+
+        SoftwareOneClaims claims;
+        try { claims = SoftwareOneJwt.ParseClaims(token); }
+        catch (Exception ex) { throw new UnauthorizedAccessException("Invalid bearer token.", ex); }
+
+        if (claims.ExpiresAt is { } exp && exp + ExpiryLeeway < DateTimeOffset.UtcNow)
+            throw new UnauthorizedAccessException("Bearer token has expired.");
+
+        if (string.IsNullOrEmpty(claims.AccountId))
+            throw new UnauthorizedAccessException("Token is missing the accountId claim.");
+
+        return new AuthContext
+        {
+            AccountId = claims.AccountId,
+            AccountType = claims.AccountType,
+            ExtensionId = claims.ExtensionId,
+            Token = token,
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests — expect pass**
+
+```bash
+dotnet test --filter FullyQualifiedName~RequestAuthenticatorTests
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat: native request authenticator (Bearer JWT -> AuthContext)"
+```
+
+### Task D3: Account-token provider (mint / cache / refresh)
+
+**Files:**
+- Create: `$DST/src/Mpt.Extensions.Sdk/Auth/IAccountTokenProvider.cs`
+- Create: `$DST/src/Mpt.Extensions.Sdk/Auth/AccountTokenProvider.cs`
+- Test: `$DST/tests/Mpt.Extensions.Sdk.Tests/AccountTokenProviderTests.cs`
+
+- [ ] **Step 1: Write the failing test (uses a stub `HttpMessageHandler`)**
+
+Create `$DST/tests/Mpt.Extensions.Sdk.Tests/AccountTokenProviderTests.cs`:
+```csharp
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Mpt.Extensions.Sdk.Auth;
+
+namespace Mpt.Extensions.Sdk.Tests;
+
+public class AccountTokenProviderTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        public int Calls;
+        public Func<HttpRequestMessage, string> TokenFor = _ => "tok";
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            Calls++;
+            var json = JsonSerializer.Serialize(new { token = TokenFor(request) });
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private static string Jwt(long expUnix)
+    {
+        static string B64(byte[] b) => Convert.ToBase64String(b).TrimEnd('=').Replace('+','-').Replace('/','_');
+        var body = B64(JsonSerializer.SerializeToUtf8Bytes(new Dictionary<string, object> { ["exp"] = expUnix }));
+        return $"{B64(Encoding.UTF8.GetBytes("{}"))}.{body}.sig";
+    }
+
+    private static AccountTokenProvider Make(StubHandler handler)
+    {
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.example/") };
+        return new AccountTokenProvider(http, extensionApiKey: "idt:EXT:key");
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_mints_then_caches_for_same_account()
+    {
+        var handler = new StubHandler { TokenFor = _ => Jwt(DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds()) };
+        var provider = Make(handler);
+
+        var t1 = await provider.GetTokenAsync("ACC-1");
+        var t2 = await provider.GetTokenAsync("ACC-1");
+
+        Assert.Equal(t1, t2);
+        Assert.Equal(1, handler.Calls); // second call served from cache
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_refreshes_when_token_near_expiry()
+    {
+        var handler = new StubHandler { TokenFor = _ => Jwt(DateTimeOffset.UtcNow.AddSeconds(10).ToUnixTimeSeconds()) };
+        var provider = Make(handler);
+
+        await provider.GetTokenAsync("ACC-1");
+        await provider.GetTokenAsync("ACC-1"); // within leeway -> re-mint
+
+        Assert.Equal(2, handler.Calls);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_calls_installations_token_endpoint_with_account_id()
+    {
+        string? path = null;
+        var handler = new StubHandler();
+        handler.TokenFor = req => { path = req.RequestUri!.PathAndQuery; return Jwt(DateTimeOffset.UtcNow.AddHours(1).ToUnixTimeSeconds()); };
+
+        await Make(handler).GetTokenAsync("ACC-42");
+
+        Assert.Equal("/public/v1/integration/installations/token?account.id=ACC-42", path);
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+```bash
+dotnet test --filter FullyQualifiedName~AccountTokenProviderTests
+```
+Expected: FAIL — types do not exist.
+
+- [ ] **Step 3: Implement the interface**
+
+Create `$DST/src/Mpt.Extensions.Sdk/Auth/IAccountTokenProvider.cs`:
+```csharp
+namespace Mpt.Extensions.Sdk.Auth;
+
+/// <summary>Supplies a valid account-scoped bearer token for Marketplace calls.</summary>
+public interface IAccountTokenProvider
+{
+    Task<string> GetTokenAsync(string accountId, CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 4: Implement the provider**
+
+Create `$DST/src/Mpt.Extensions.Sdk/Auth/AccountTokenProvider.cs`:
+```csharp
+using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+namespace Mpt.Extensions.Sdk.Auth;
+
+/// <summary>
+/// Mints per-account tokens via <c>POST /public/v1/integration/installations/token?account.id={id}</c>
+/// using the extension API key, caches them, and refreshes within a leeway window. Minting is
+/// serialized per account so concurrent requests for the same account mint once.
+/// </summary>
+public sealed class AccountTokenProvider : IAccountTokenProvider
+{
+    private static readonly TimeSpan RefreshLeeway = TimeSpan.FromSeconds(60);
+
+    private readonly HttpClient _http;
+    private readonly string _extensionApiKey;
+    private readonly ConcurrentDictionary<string, (string Token, DateTimeOffset ExpiresAt)> _cache = new();
+    private readonly ConcurrentDictionary<string, SemaphoreSlim> _locks = new();
+
+    public AccountTokenProvider(HttpClient http, string extensionApiKey)
+    {
+        _http = http;
+        _extensionApiKey = extensionApiKey;
+    }
+
+    public async Task<string> GetTokenAsync(string accountId, CancellationToken ct = default)
+    {
+        if (TryGetFresh(accountId, out var cached))
+            return cached;
+
+        var gate = _locks.GetOrAdd(accountId, _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(ct);
+        try
+        {
+            if (TryGetFresh(accountId, out cached))
+                return cached;
+
+            var (token, expiresAt) = await MintAsync(accountId, ct);
+            _cache[accountId] = (token, expiresAt);
+            return token;
+        }
+        finally { gate.Release(); }
+    }
+
+    private bool TryGetFresh(string accountId, out string token)
+    {
+        if (_cache.TryGetValue(accountId, out var e) && e.ExpiresAt - RefreshLeeway > DateTimeOffset.UtcNow)
+        {
+            token = e.Token;
+            return true;
+        }
+        token = "";
+        return false;
+    }
+
+    private async Task<(string Token, DateTimeOffset ExpiresAt)> MintAsync(string accountId, CancellationToken ct)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Post,
+            $"/public/v1/integration/installations/token?account.id={Uri.EscapeDataString(accountId)}");
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _extensionApiKey);
+
+        using var res = await _http.SendAsync(req, ct);
+        res.EnsureSuccessStatusCode();
+
+        var body = await res.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken: ct)
+            ?? throw new InvalidOperationException("Token endpoint returned an empty body.");
+        if (string.IsNullOrEmpty(body.Token))
+            throw new InvalidOperationException("Token endpoint returned no token.");
+
+        var expiresAt = SoftwareOneJwt.ParseClaims(body.Token).ExpiresAt
+            ?? DateTimeOffset.UtcNow.AddMinutes(5);
+        return (body.Token, expiresAt);
+    }
+
+    private sealed record TokenResponse(string Token);
+}
+```
+Note: `ReadFromJsonAsync<TokenResponse>` uses Web defaults (camelCase), so the JSON `{"token":"..."}` maps to `Token`.
+
+- [ ] **Step 5: Run the tests — expect pass**
+
+```bash
+dotnet test --filter FullyQualifiedName~AccountTokenProviderTests
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat: account-scoped token provider (mint/cache/refresh)"
+```
+
+### Task D4: Direct account-scoped Marketplace client
+
+**Files:**
+- Create: `$DST/src/Mpt.Extensions.Sdk/Marketplace/HttpMarketplaceClient.cs`
+- Test: `$DST/tests/Mpt.Extensions.Sdk.Tests/HttpMarketplaceClientTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `$DST/tests/Mpt.Extensions.Sdk.Tests/HttpMarketplaceClientTests.cs`:
+```csharp
+using System.Net;
+using System.Text;
+using System.Text.Json.Serialization;
+using Mpt.Extensions.Sdk.Auth;
+using Mpt.Extensions.Sdk.Marketplace;
+using Mpt.Extensions.Sdk.Serialization;
+
+namespace Mpt.Extensions.Sdk.Tests;
+
+public class HttpMarketplaceClientTests
+{
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Last;
+        public string ResponseJson = "{}";
+        public HttpStatusCode Status = HttpStatusCode.OK;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Last = request;
+            return Task.FromResult(new HttpResponseMessage(Status)
+            {
+                Content = new StringContent(ResponseJson, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class StubTokens : IAccountTokenProvider
+    {
+        public Task<string> GetTokenAsync(string accountId, CancellationToken ct = default) =>
+            Task.FromResult($"token-for-{accountId}");
+    }
+
+    private sealed class Order
+    {
+        [JsonPropertyName("id")] public string Id { get; init; } = "";
+    }
+
+    private static HttpMarketplaceClient Make(CapturingHandler handler) =>
+        new(new HttpClient(handler) { BaseAddress = new Uri("https://api.example/") },
+            new StubTokens(), accountId: "ACC-1", MptJson.Default);
+
+    [Fact]
+    public async Task GetAsync_attaches_account_token_and_returns_typed_body()
+    {
+        var handler = new CapturingHandler { ResponseJson = "{\"id\":\"ORD-1\"}" };
+        var order = await Make(handler).GetAsync<Order>("/commerce/orders/ORD-1");
+
+        Assert.Equal("ORD-1", order.Id);
+        Assert.Equal(HttpMethod.Get, handler.Last!.Method);
+        Assert.Equal("/commerce/orders/ORD-1", handler.Last.RequestUri!.PathAndQuery);
+        Assert.Equal("token-for-ACC-1", handler.Last.Headers.Authorization!.Parameter);
+        Assert.Equal("Bearer", handler.Last.Headers.Authorization.Scheme);
+    }
+
+    [Fact]
+    public async Task PutAsync_sends_body()
+    {
+        var handler = new CapturingHandler { ResponseJson = "{\"id\":\"ORD-1\"}" };
+        await Make(handler).PutAsync<Order>("/commerce/orders/ORD-1", new { note = "x" });
+
+        Assert.Equal(HttpMethod.Put, handler.Last!.Method);
+        Assert.NotNull(handler.Last.Content);
+    }
+
+    [Fact]
+    public async Task Non_success_throws_MarketplaceApiException_with_status_and_body()
+    {
+        var handler = new CapturingHandler { Status = HttpStatusCode.NotFound, ResponseJson = "{\"error\":\"nope\"}" };
+        var ex = await Assert.ThrowsAsync<MarketplaceApiException>(
+            () => Make(handler).GetAsync<Order>("/commerce/orders/ORD-X"));
+        Assert.Equal(404, ex.StatusCode);
+        Assert.Contains("nope", ex.Message);
+    }
+}
+```
+Note: confirm `MarketplaceApiException` exposes an `int StatusCode` and the body in `Message` (it was ported in Task B2; if the property name differs, align the test with the ported type rather than inventing a new one).
+
+- [ ] **Step 2: Run it — expect failure**
+
+```bash
+dotnet test --filter FullyQualifiedName~HttpMarketplaceClientTests
+```
+Expected: FAIL — `HttpMarketplaceClient` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `$DST/src/Mpt.Extensions.Sdk/Marketplace/HttpMarketplaceClient.cs`:
+```csharp
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Mpt.Extensions.Sdk.Auth;
+
+namespace Mpt.Extensions.Sdk.Marketplace;
+
+/// <summary>
+/// Calls the Marketplace API directly (over whatever transport the HttpClient is bound to —
+/// plain HTTP locally, Ziti on the platform), attaching a fresh account-scoped token per request.
+/// Generic: the caller chooses the model type <typeparamref name="T"/>.
+/// </summary>
+public sealed class HttpMarketplaceClient : IMarketplaceClient
+{
+    private readonly HttpClient _http;
+    private readonly IAccountTokenProvider _tokens;
+    private readonly string _accountId;
+    private readonly JsonSerializerOptions _json;
+
+    public HttpMarketplaceClient(HttpClient http, IAccountTokenProvider tokens, string accountId,
+        JsonSerializerOptions json)
+    {
+        _http = http;
+        _tokens = tokens;
+        _accountId = accountId;
+        _json = json;
+    }
+
+    public Task<T> GetAsync<T>(string path, CancellationToken ct = default) =>
+        SendAsync<T>(HttpMethod.Get, path, body: null, ct);
+
+    public Task<T> PostAsync<T>(string path, object? body, CancellationToken ct = default) =>
+        SendAsync<T>(HttpMethod.Post, path, body, ct);
+
+    public Task<T> PutAsync<T>(string path, object? body, CancellationToken ct = default) =>
+        SendAsync<T>(HttpMethod.Put, path, body, ct);
+
+    private async Task<T> SendAsync<T>(HttpMethod method, string path, object? body, CancellationToken ct)
+    {
+        using var req = new HttpRequestMessage(method, path);
+        var token = await _tokens.GetTokenAsync(_accountId, ct);
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        if (body is not null)
+            req.Content = new StringContent(JsonSerializer.Serialize(body, _json), Encoding.UTF8, "application/json");
+
+        using var res = await _http.SendAsync(req, ct);
+        var payload = await res.Content.ReadAsStringAsync(ct);
+
+        if (!res.IsSuccessStatusCode)
+            throw new MarketplaceApiException((int)res.StatusCode, payload);
+
+        if (string.IsNullOrWhiteSpace(payload))
+            throw new MarketplaceApiException((int)res.StatusCode, "Marketplace returned an empty success body.");
+
+        return JsonSerializer.Deserialize<T>(payload, _json)
+            ?? throw new MarketplaceApiException((int)res.StatusCode, "Marketplace returned a null body.");
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests — expect pass**
+
+```bash
+dotnet test --filter FullyQualifiedName~HttpMarketplaceClientTests
+```
+Expected: PASS. If `MarketplaceApiException`'s constructor/shape differs from `(int, string)`, adapt this implementation to the ported type (do not change the ported exception).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat: direct account-scoped HttpMarketplaceClient (generic)"
+```
+
+### Task D5: Typed runtime options
+
+**Files:**
+- Create: `$DST/src/Mpt.Extensions.Sdk/Hosting/ExtensionOptions.cs`
+- Test: `$DST/tests/Mpt.Extensions.Sdk.Tests/ExtensionOptionsTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `$DST/tests/Mpt.Extensions.Sdk.Tests/ExtensionOptionsTests.cs`:
+```csharp
+using Microsoft.Extensions.Configuration;
+using Mpt.Extensions.Sdk.Hosting;
+
+namespace Mpt.Extensions.Sdk.Tests;
+
+public class ExtensionOptionsTests
+{
+    [Fact]
+    public void FromConfiguration_reads_sdk_env_keys()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["SDK_EXTENSION_ID"] = "EXT-5034-5001",
+            ["SDK_EXTENSION_API_KEY"] = "idt:EXT-5034-5001:secret",
+            ["SDK_EXTENSION_URL"] = "https://api.s1.show",
+            ["MPT_API_BASE_URL"] = "https://api.s1.show/public/v1",
+            ["SDK_IDENTITY_FILE_PATH"] = "./identity/identity.json",
+        }).Build();
+
+        var o = ExtensionOptions.FromConfiguration(config);
+
+        Assert.Equal("EXT-5034-5001", o.ExtensionId);
+        Assert.Equal("EXT-5034-5001", o.ExternalId); // defaults to extension id when not set
+        Assert.Equal("idt:EXT-5034-5001:secret", o.ExtensionApiKey);
+        Assert.Equal("https://api.s1.show", o.PlatformUrl);
+        Assert.Equal("https://api.s1.show/public/v1", o.MarketplaceApiBaseUrl);
+        Assert.Equal("./identity/identity.json", o.IdentityFilePath);
+    }
+
+    [Fact]
+    public void ExternalId_uses_explicit_value_when_present()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["SDK_EXTENSION_ID"] = "EXT-1",
+            ["SDK_EXTENSION_EXTERNAL_ID"] = "EXT-EXTERNAL",
+        }).Build();
+
+        Assert.Equal("EXT-EXTERNAL", ExtensionOptions.FromConfiguration(config).ExternalId);
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+```bash
+dotnet test --filter FullyQualifiedName~ExtensionOptionsTests
+```
+Expected: FAIL — `ExtensionOptions` does not exist.
+
+- [ ] **Step 3: Implement (replaces the old bridge-oriented `HostOptions`)**
+
+Create `$DST/src/Mpt.Extensions.Sdk/Hosting/ExtensionOptions.cs`:
+```csharp
+using Microsoft.Extensions.Configuration;
+
+namespace Mpt.Extensions.Sdk.Hosting;
+
+/// <summary>Runtime options resolved from environment/configuration when the host is built.</summary>
+public sealed class ExtensionOptions
+{
+    public required string ExtensionId { get; init; }
+    public required string ExternalId { get; init; }
+    public string? ExtensionApiKey { get; init; }
+    public string? PlatformUrl { get; init; }
+    public string? MarketplaceApiBaseUrl { get; init; }
+    public string IdentityFilePath { get; init; } = "identity/identity.json";
+
+    /// <summary>Platform version reported during registration (from meta/config).</summary>
+    public string Version { get; init; } = "0.0.0";
+
+    public static ExtensionOptions FromConfiguration(IConfiguration config)
+    {
+        var extensionId = config["SDK_EXTENSION_ID"] ?? "";
+        return new ExtensionOptions
+        {
+            ExtensionId = extensionId,
+            ExternalId = config["SDK_EXTENSION_EXTERNAL_ID"] ?? extensionId,
+            ExtensionApiKey = config["SDK_EXTENSION_API_KEY"],
+            PlatformUrl = config["SDK_EXTENSION_URL"],
+            MarketplaceApiBaseUrl = config["MPT_API_BASE_URL"],
+            IdentityFilePath = config["SDK_IDENTITY_FILE_PATH"] ?? "identity/identity.json",
+            Version = config["SDK_EXTENSION_VERSION"] ?? "0.0.0",
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Run the test — expect pass**
+
+```bash
+dotnet test --filter FullyQualifiedName~ExtensionOptionsTests
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat: typed ExtensionOptions from configuration"
+```
+
+### Task D6: Port + rewire the host pipeline (native auth, native Marketplace client)
+
+**Files:**
+- Create: `$DST/src/Mpt.Extensions.Sdk/Hosting/ExtensionEndpoints.cs` (ported, rewired)
+- Create: `$DST/src/Mpt.Extensions.Sdk/Hosting/ExtensionHostBuilder.cs` (ported, rewired)
+- Modify (restore): `$DST/tests/Mpt.Extensions.Sdk.Tests/HostIntegrationTests.cs`
+
+- [ ] **Step 1: Port the two Hosting files**
+
+```bash
+SRC='C:/repos/mpt-extension-dotnet-sdk/src/Mpt.Extensions.Sdk/Hosting'
+DST='C:/repos/mpt-extension-sdk-dotnet/src/Mpt.Extensions.Sdk/Hosting'
+cp "$SRC/ExtensionEndpoints.cs" "$DST/ExtensionEndpoints.cs"
+cp "$SRC/ExtensionHostBuilder.cs" "$DST/ExtensionHostBuilder.cs"
+```
+
+- [ ] **Step 2: Rewire `ExtensionEndpoints.cs` — replace bridge auth/egress with native equivalents**
+
+Make these exact edits in `$DST/src/Mpt.Extensions.Sdk/Hosting/ExtensionEndpoints.cs`:
+
+(a) Replace the `ParseAuth` method body so it uses the real Bearer JWT instead of the `X-Mpt-Auth` header:
+```csharp
+    private static AuthContext ParseAuth(HttpContext http) =>
+        new RequestAuthenticator().Authenticate(http);
+```
+Add `using Mpt.Extensions.Sdk.Auth;` if not already present.
+
+(b) Remove the bridge-token gate: delete the `Unauthorized(...)` call in `RunGuarded` and the `Unauthorized` method, and drop the `options.BridgeToken` usage. Authentication failures now surface as `UnauthorizedAccessException` from `ParseAuth`; catch them in `RunGuarded` and return 401:
+```csharp
+        try
+        {
+            var services = new HandlerServices(
+                scope.ServiceProvider, NewClient(httpFactory, http), logger);
+            return await body(services, http);
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            logger.LogWarning(ex, "{Label} request to {Path} failed authentication", label, http.Request.Path);
+            return Error(StatusCodes.Status401Unauthorized, "unauthorized", ex.Message);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "{Label} handler for {Path} failed", label, http.Request.Path);
+            return Error(StatusCodes.Status500InternalServerError, "handler_failed", ex.Message);
+        }
+```
+Important: `ParseAuth` is called inside each route `body` (e.g. `route.Invoke(evt, ParseAuth(h), ...)`), so the `UnauthorizedAccessException` is thrown within the `try` and mapped to 401. Keep it that way.
+
+(c) Replace `NewClient` (which built the bridge `EgressMarketplaceClient` from the `X-Mpt-Egress-Session` header) with one that builds the native account-scoped client. It needs the authenticated account id, the account-token provider, the Marketplace base URL, and the JSON options — all resolved from DI. Change the per-request client construction so it happens **after** auth (it needs the account id). Concretely:
+  - Delete the `NewClient(IHttpClientFactory, HttpContext)` method and the `EgressClientName` egress constant usage for client creation.
+  - Build `HandlerServices` lazily with a factory that, given the parsed `AuthContext`, returns an `IMarketplaceClient`:
+```csharp
+        var services = new HandlerServices(
+            scope.ServiceProvider,
+            marketplaceFor: auth => new HttpMarketplaceClient(
+                httpFactory.CreateClient(MarketplaceClientName),
+                scope.ServiceProvider.GetRequiredService<IAccountTokenProvider>(),
+                auth.AccountId,
+                scope.ServiceProvider.GetRequiredService<JsonSerializerOptions>()),
+            logger);
+```
+  This requires `HandlerServices` to support resolving the Marketplace client from the auth context. See Step 3 for the `HandlerServices` change. Add `internal const string MarketplaceClientName = "mpt-marketplace";` and `using System.Text.Json;`, `using Mpt.Extensions.Sdk.Marketplace;`.
+
+(d) Keep `/__health` and `/__manifest`, the correlation-id log scope (`x-request-id`/`mpt-task-id`), route mapping, body handling, and the error envelope unchanged.
+
+- [ ] **Step 3: Update `HandlerServices` so the Marketplace client is built from the auth context**
+
+The ported `HandlerServices` currently takes a concrete `IMarketplaceClient`. The native flow needs the account id (from auth) to build the client. Open `$DST/src/Mpt.Extensions.Sdk/Contexts/HandlerServices.cs` and the context types (`EventContext`, `ApiContext`) and adjust so the per-request `IMarketplaceClient` is created once the `AuthContext` is known.
+
+Minimal, low-churn approach: give `HandlerServices` a constructor overload taking a `Func<AuthContext, IMarketplaceClient> marketplaceFor` plus the parsed `AuthContext`, and have `Marketplace` resolve lazily:
+```csharp
+using Microsoft.Extensions.Logging;
+using Mpt.Extensions.Sdk.Auth;
+using Mpt.Extensions.Sdk.Marketplace;
+
+namespace Mpt.Extensions.Sdk.Contexts;
+
+public sealed class HandlerServices
+{
+    private readonly Lazy<IMarketplaceClient> _marketplace;
+
+    public HandlerServices(IServiceProvider services, IMarketplaceClient marketplace, ILogger logger)
+        : this(services, _ => marketplace, auth: new AuthContext(), logger) { }
+
+    public HandlerServices(IServiceProvider services, Func<AuthContext, IMarketplaceClient> marketplaceFor,
+        AuthContext auth, ILogger logger)
+    {
+        Services = services;
+        Logger = logger;
+        _marketplace = new Lazy<IMarketplaceClient>(() => marketplaceFor(auth));
+    }
+
+    public IServiceProvider Services { get; }
+    public IMarketplaceClient Marketplace => _marketplace.Value;
+    public ILogger Logger { get; }
+}
+```
+Then in `ExtensionEndpoints.RunGuarded`, parse auth first and pass it in. Adjust the route bodies so they receive the already-parsed `AuthContext` (parse once per request, not once per `ParseAuth` call). If the ported dispatch signature passes `auth` into the invoker, thread the single parsed `AuthContext` through both `HandlerServices` and the invoker. Keep the change surface minimal and re-run the build after.
+
+- [ ] **Step 4: Rewire `ExtensionHostBuilder.cs` — register native services, drop egress defaults**
+
+Edit `$DST/src/Mpt.Extensions.Sdk/Hosting/ExtensionHostBuilder.cs`:
+  - Remove `DefaultEgressUrl` and the `MPT_EGRESS_URL`/`MPT_BRIDGE_TOKEN` `HostOptions` wiring.
+  - Resolve `ExtensionOptions.FromConfiguration(builder.Configuration)` and register it as a singleton.
+  - Register the shared JSON options: `builder.Services.AddSingleton(MptJson.Default);` (consumers can replace this registration to add converters for platform contracts).
+  - Register the account-token provider as a singleton backed by a named HttpClient pointed at the platform URL:
+```csharp
+builder.Services.AddHttpClient("mpt-tokens", (sp, c) =>
+{
+    var o = sp.GetRequiredService<ExtensionOptions>();
+    c.BaseAddress = new Uri(o.PlatformUrl ?? "http://localhost");
+});
+builder.Services.AddSingleton<IAccountTokenProvider>(sp =>
+{
+    var o = sp.GetRequiredService<ExtensionOptions>();
+    var http = sp.GetRequiredService<IHttpClientFactory>().CreateClient("mpt-tokens");
+    return new AccountTokenProvider(http, o.ExtensionApiKey ?? "");
+});
+```
+  - Register the named Marketplace HttpClient (`ExtensionEndpoints.MarketplaceClientName`) pointed at `MarketplaceApiBaseUrl`, with a 2-minute pooled connection lifetime (as the old egress client had):
+```csharp
+builder.Services.AddHttpClient(ExtensionEndpoints.MarketplaceClientName, (sp, c) =>
+{
+    var o = sp.GetRequiredService<ExtensionOptions>();
+    c.BaseAddress = new Uri(o.MarketplaceApiBaseUrl ?? "http://localhost");
+}).ConfigurePrimaryHttpMessageHandler(() =>
+    new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(2) });
+```
+  - Keep the generated-registry vs reflection-discovery branch and `AddStatic` exactly as ported, but pass the rewired `HostOptions`/options object through (or drop `HostOptions` entirely if no longer needed by `ExtensionEndpoints.Map*`). Ensure `Map`/`MapGenerated` no longer require a `BridgeToken`.
+
+- [ ] **Step 5: Restore and rewire `HostIntegrationTests`**
+
+```bash
+DST='C:/repos/mpt-extension-sdk-dotnet/tests/Mpt.Extensions.Sdk.Tests'
+mv "$DST/HostIntegrationTests.cs.pending" "$DST/HostIntegrationTests.cs"
+```
+Then overwrite `$DST/tests/Mpt.Extensions.Sdk.Tests/HostIntegrationTests.cs` to use a real Bearer JWT and drop the bridge-token/egress-session/`X-Mpt-Auth` headers:
+```csharp
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Mpt.Extensions.Sdk.Attributes;
+using Mpt.Extensions.Sdk.Contexts;
+using Mpt.Extensions.Sdk.Events;
+using Mpt.Extensions.Sdk.Hosting;
+
+namespace Mpt.Extensions.Sdk.Tests;
+
+public class HostIntegrationTests
+{
+    public class TestHandlers
+    {
+        [EventHandler(Event = "order.created", Path = "/events/host-orders")]
+        public Task<EventResponse> OnCreated(OrderContext ctx) =>
+            Task.FromResult(ctx.OrderId == "ORD-1" ? EventResponse.Ok() : EventResponse.Cancel("unknown"));
+
+        [ApiEndpoint("GET", "/host-me")]
+        public Task<object> Me(ApiContext ctx) => Task.FromResult<object>(new { account = ctx.Auth.AccountId });
+    }
+
+    private static string Bearer(string accountId)
+    {
+        static string B64(byte[] b) => Convert.ToBase64String(b).TrimEnd('=').Replace('+','-').Replace('/','_');
+        var body = B64(JsonSerializer.SerializeToUtf8Bytes(new Dictionary<string, object>
+        {
+            ["https://claims.softwareone.com/accountId"] = accountId,
+            ["exp"] = DateTimeOffset.UtcNow.AddMinutes(10).ToUnixTimeSeconds(),
+        }));
+        return $"{B64(Encoding.UTF8.GetBytes("{}"))}.{body}.sig";
+    }
+
+    private static TestServer BuildServer()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        var app = ExtensionHostBuilder.Build(builder, typeof(TestHandlers).Assembly);
+        app.Start();
+        return (TestServer)app.Services.GetRequiredService<IServer>();
+    }
+
+    [Fact]
+    public async Task Health_returns_ok()
+    {
+        using var server = BuildServer();
+        var res = await server.CreateClient().GetAsync("/__health");
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task Posting_event_with_valid_bearer_dispatches()
+    {
+        using var server = BuildServer();
+        var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add("Authorization", $"Bearer {Bearer("ACC-1")}");
+        var body = new StringContent("{\"id\":\"E1\",\"object\":{\"id\":\"ORD-1\"},\"details\":{}}",
+            Encoding.UTF8, "application/json");
+
+        var res = await client.PostAsync("/events/host-orders", body);
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        Assert.Contains("\"response\":\"OK\"", await res.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task Event_without_bearer_returns_401()
+    {
+        using var server = BuildServer();
+        var body = new StringContent("{\"id\":\"E1\",\"object\":{\"id\":\"ORD-1\"},\"details\":{}}",
+            Encoding.UTF8, "application/json");
+        var res = await server.CreateClient().PostAsync("/events/host-orders", body);
+        Assert.Equal(HttpStatusCode.Unauthorized, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task Api_endpoint_reads_account_from_bearer()
+    {
+        using var server = BuildServer();
+        var client = server.CreateClient();
+        client.DefaultRequestHeaders.Add("Authorization", $"Bearer {Bearer("ACC-7")}");
+        var res = await client.GetAsync("/host-me");
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        Assert.Contains("ACC-7", await res.Content.ReadAsStringAsync());
+    }
+}
+```
+
+- [ ] **Step 6: Build and run the full suite**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+dotnet test
+```
+Expected: all tests pass, including the rewired `HostIntegrationTests`. Iterate on the Step 2–4 edits until green (the rewiring is the most involved change; expect a few compile fixes around `HandlerServices`/`ParseAuth` threading).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "feat: native host pipeline (Bearer JWT auth + account-scoped Marketplace client)"
+```
+
+### Task D7: Identity store
+
+**Files:**
+- Create: `$DST/src/Mpt.Extensions.Sdk/Registration/IdentityStore.cs`
+- Test: `$DST/tests/Mpt.Extensions.Sdk.Tests/IdentityStoreTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `$DST/tests/Mpt.Extensions.Sdk.Tests/IdentityStoreTests.cs`:
+```csharp
+using System.Text.Json;
+using Mpt.Extensions.Sdk.Registration;
+
+namespace Mpt.Extensions.Sdk.Tests;
+
+public class IdentityStoreTests
+{
+    [Fact]
+    public void Load_returns_empty_when_file_absent()
+    {
+        var store = new IdentityStore(Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.json"));
+        Assert.Null(store.Load());
+    }
+
+    [Fact]
+    public void Save_then_Load_round_trips_and_creates_directory()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"id-{Guid.NewGuid():N}");
+        var path = Path.Combine(dir, "identity.json");
+        var store = new IdentityStore(path);
+
+        using var doc = JsonDocument.Parse("{\"mrok\":{\"extension\":\"EXT-1\"}}");
+        store.Save(doc.RootElement);
+
+        var loaded = store.Load();
+        Assert.NotNull(loaded);
+        Assert.Equal("EXT-1", loaded!.Value.GetProperty("mrok").GetProperty("extension").GetString());
+    }
+
+    [Fact]
+    public void MatchesExtension_is_case_insensitive()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"id-{Guid.NewGuid():N}");
+        var store = new IdentityStore(Path.Combine(dir, "identity.json"));
+        using var doc = JsonDocument.Parse("{\"mrok\":{\"extension\":\"EXT-1\"}}");
+        store.Save(doc.RootElement);
+
+        Assert.True(store.MatchesExtension("ext-1"));
+        Assert.False(store.MatchesExtension("EXT-2"));
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+```bash
+dotnet test --filter FullyQualifiedName~IdentityStoreTests
+```
+Expected: FAIL — `IdentityStore` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `$DST/src/Mpt.Extensions.Sdk/Registration/IdentityStore.cs`:
+```csharp
+using System.Text.Json;
+
+namespace Mpt.Extensions.Sdk.Registration;
+
+/// <summary>Reads/writes the persisted OpenZiti identity (the platform's channel.identity).</summary>
+public sealed class IdentityStore
+{
+    private readonly string _path;
+
+    public IdentityStore(string path) => _path = path;
+
+    public JsonElement? Load()
+    {
+        if (!File.Exists(_path))
+            return null;
+        using var doc = JsonDocument.Parse(File.ReadAllText(_path));
+        return doc.RootElement.Clone();
+    }
+
+    public void Save(JsonElement identity)
+    {
+        var dir = Path.GetDirectoryName(_path);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+        File.WriteAllText(_path, JsonSerializer.Serialize(identity));
+    }
+
+    /// <summary>True when the persisted identity's <c>mrok.extension</c> matches (case-insensitive).</summary>
+    public bool MatchesExtension(string extensionId)
+    {
+        var id = Load();
+        if (id is null)
+            return false;
+        if (!id.Value.TryGetProperty("mrok", out var mrok) ||
+            !mrok.TryGetProperty("extension", out var ext))
+            return false;
+        return string.Equals(ext.GetString(), extensionId, StringComparison.OrdinalIgnoreCase);
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests — expect pass**
+
+```bash
+dotnet test --filter FullyQualifiedName~IdentityStoreTests
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat: identity store (persist platform channel.identity)"
+```
+
+### Task D8: Meta builder (manifest → registration meta block)
+
+**Files:**
+- Create: `$DST/src/Mpt.Extensions.Sdk/Registration/MetaBuilder.cs`
+- Test: `$DST/tests/Mpt.Extensions.Sdk.Tests/MetaBuilderTests.cs`
+
+> Read the ported `Manifest/ExtensionManifest.cs` and `Manifest/RouteDescriptor.cs` first to use their real property names. The test/impl below assume `manifest.Events` items expose `Event` (string), `Path` (string), `Condition` (string?), and a task flag. Align names to the actual ported types.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `$DST/tests/Mpt.Extensions.Sdk.Tests/MetaBuilderTests.cs`:
+```csharp
+using System.Text.Json;
+using Mpt.Extensions.Sdk.Manifest;
+using Mpt.Extensions.Sdk.Registration;
+
+namespace Mpt.Extensions.Sdk.Tests;
+
+public class MetaBuilderTests
+{
+    [Fact]
+    public void Build_emits_contract_version_and_event_entries()
+    {
+        // Build a manifest with one event route using the real ExtensionManifest API.
+        var manifest = SampleManifest.WithOneEvent(
+            eventName: "platform.catalog.productItem.created",
+            path: "/events/platform-catalog-productitem-created",
+            condition: "eq(product.id,PRD-1)",
+            isTask: false);
+
+        var meta = MetaBuilder.Build(manifest);
+        var json = JsonSerializer.SerializeToElement(meta, MetaBuilder.JsonOptions);
+
+        Assert.Equal("1", json.GetProperty("contractVersion").GetString());
+        var evt = json.GetProperty("events")[0];
+        Assert.Equal("platform.catalog.productItem.created", evt.GetProperty("event").GetString());
+        Assert.Equal("/events/platform-catalog-productitem-created", evt.GetProperty("path").GetString());
+        Assert.Equal("eq(product.id,PRD-1)", evt.GetProperty("condition").GetString());
+        Assert.False(evt.GetProperty("task").GetBoolean());
+        Assert.Equal(0, json.GetProperty("apiEndpoints").GetArrayLength());
+    }
+}
+```
+Add a small helper `SampleManifest.WithOneEvent(...)` in the test project that constructs an `ExtensionManifest` with one event route using the ported type's actual constructor/add API. (Inspect `ExtensionManifest`/`RouteDescriptor` to write this — do not guess.)
+
+- [ ] **Step 2: Run it — expect failure**
+
+```bash
+dotnet test --filter FullyQualifiedName~MetaBuilderTests
+```
+Expected: FAIL — `MetaBuilder` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `$DST/src/Mpt.Extensions.Sdk/Registration/MetaBuilder.cs` (map the ported manifest's real property names into the wire shape captured from the POC):
+```csharp
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Mpt.Extensions.Sdk.Manifest;
+
+namespace Mpt.Extensions.Sdk.Registration;
+
+/// <summary>The registration <c>meta</c> block (basis for meta.yaml), per the platform wire contract.</summary>
+public sealed class MetaConfig
+{
+    [JsonPropertyName("contractVersion")] public string ContractVersion { get; init; } = "1";
+    [JsonPropertyName("events")] public List<MetaEvent> Events { get; init; } = new();
+    [JsonPropertyName("apiEndpoints")] public List<MetaApiEndpoint> ApiEndpoints { get; init; } = new();
+    [JsonPropertyName("schedules")] public List<object> Schedules { get; init; } = new();
+    [JsonPropertyName("plugs")] public List<object> Plugs { get; init; } = new();
+}
+
+public sealed class MetaEvent
+{
+    [JsonPropertyName("event")] public required string Event { get; init; }
+    [JsonPropertyName("path")] public required string Path { get; init; }
+    [JsonPropertyName("condition")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Condition { get; init; }
+    [JsonPropertyName("task")] public bool Task { get; init; }
+}
+
+public sealed class MetaApiEndpoint
+{
+    [JsonPropertyName("method")] public required string Method { get; init; }
+    [JsonPropertyName("path")] public required string Path { get; init; }
+}
+
+public static class MetaBuilder
+{
+    public static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = false };
+
+    public static MetaConfig Build(ExtensionManifest manifest)
+    {
+        var meta = new MetaConfig();
+        foreach (var e in manifest.Events)
+        {
+            meta.Events.Add(new MetaEvent
+            {
+                // Align these accessors to the real ExtensionManifest event-route type.
+                Event = e.Event,
+                Path = e.Path,
+                Condition = e.Condition,
+                Task = e.DeliveryIsTask, // adjust to the real flag name
+            });
+        }
+        foreach (var a in manifest.ApiEndpoints)
+        {
+            meta.ApiEndpoints.Add(new MetaApiEndpoint { Method = a.Method, Path = a.Path });
+        }
+        return meta;
+    }
+}
+```
+Adjust the property accessors (`e.Event`, `e.Path`, `e.Condition`, `e.DeliveryIsTask`, `a.Method`, `a.Path`) to match the ported `ExtensionManifest` exactly.
+
+- [ ] **Step 4: Run the test — expect pass**
+
+```bash
+dotnet test --filter FullyQualifiedName~MetaBuilderTests
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat: meta builder (manifest -> registration meta block)"
+```
+
+### Task D9: Registration service
+
+**Files:**
+- Create: `$DST/src/Mpt.Extensions.Sdk/Registration/RegistrationPayload.cs`
+- Create: `$DST/src/Mpt.Extensions.Sdk/Registration/RegistrationService.cs`
+- Test: `$DST/tests/Mpt.Extensions.Sdk.Tests/RegistrationServiceTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `$DST/tests/Mpt.Extensions.Sdk.Tests/RegistrationServiceTests.cs`:
+```csharp
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Mpt.Extensions.Sdk.Hosting;
+using Mpt.Extensions.Sdk.Registration;
+
+namespace Mpt.Extensions.Sdk.Tests;
+
+public class RegistrationServiceTests
+{
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? Last;
+        public string? LastBody;
+        public string ResponseJson = "{}";
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            Last = request;
+            LastBody = request.Content is null ? null : await request.Content.ReadAsStringAsync(ct);
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(ResponseJson, Encoding.UTF8, "application/json"),
+            };
+        }
+    }
+
+    private static (RegistrationService svc, CapturingHandler handler, string idPath) Make(string? existingIdentity = null)
+    {
+        var handler = new CapturingHandler();
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://api.s1.show") };
+        var idPath = Path.Combine(Path.GetTempPath(), $"reg-{Guid.NewGuid():N}", "identity.json");
+        if (existingIdentity is not null)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(idPath)!);
+            File.WriteAllText(idPath, existingIdentity);
+        }
+        var options = new ExtensionOptions
+        {
+            ExtensionId = "EXT-1", ExternalId = "EXT-1", ExtensionApiKey = "idt:EXT-1:key",
+            PlatformUrl = "https://api.s1.show", IdentityFilePath = idPath, Version = "1.2.3",
+        };
+        return (new RegistrationService(http, options, new IdentityStore(idPath)), handler, idPath);
+    }
+
+    [Fact]
+    public async Task Register_posts_to_instances_endpoint_with_bearer_and_persists_identity()
+    {
+        var (svc, handler, idPath) = Make();
+        handler.ResponseJson = "{\"channel\":{\"identity\":{\"mrok\":{\"extension\":\"EXT-1\"}}}}";
+
+        var meta = new MetaConfig();
+        await svc.RegisterAsync(meta);
+
+        Assert.Equal(HttpMethod.Post, handler.Last!.Method);
+        Assert.Equal("/public/v1/integration/extensions/EXT-1/instances", handler.Last.RequestUri!.PathAndQuery);
+        Assert.Equal("idt:EXT-1:key", handler.Last.Headers.Authorization!.Parameter);
+
+        using var sent = JsonDocument.Parse(handler.LastBody!);
+        Assert.Equal("EXT-1", sent.RootElement.GetProperty("externalId").GetString());
+        Assert.Equal("1.2.3", sent.RootElement.GetProperty("version").GetString());
+        Assert.True(sent.RootElement.TryGetProperty("channel", out _)); // fresh -> requests a channel
+
+        Assert.True(File.Exists(idPath));
+    }
+
+    [Fact]
+    public async Task Register_omits_channel_when_matching_identity_exists()
+    {
+        var (svc, handler, _) = Make(existingIdentity: "{\"mrok\":{\"extension\":\"EXT-1\"}}");
+        handler.ResponseJson = "{}";
+
+        await svc.RegisterAsync(new MetaConfig());
+
+        using var sent = JsonDocument.Parse(handler.LastBody!);
+        Assert.False(sent.RootElement.TryGetProperty("channel", out _)); // identity reused
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+```bash
+dotnet test --filter FullyQualifiedName~RegistrationServiceTests
+```
+Expected: FAIL — types do not exist.
+
+- [ ] **Step 3: Implement the payload DTO**
+
+Create `$DST/src/Mpt.Extensions.Sdk/Registration/RegistrationPayload.cs`:
+```csharp
+using System.Text.Json.Serialization;
+
+namespace Mpt.Extensions.Sdk.Registration;
+
+internal sealed class RegistrationPayload
+{
+    [JsonPropertyName("externalId")] public required string ExternalId { get; init; }
+    [JsonPropertyName("version")] public required string Version { get; init; }
+    [JsonPropertyName("meta")] public required MetaConfig Meta { get; init; }
+
+    [JsonPropertyName("channel")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public object? Channel { get; init; }
+}
+```
+
+- [ ] **Step 4: Implement the service**
+
+Create `$DST/src/Mpt.Extensions.Sdk/Registration/RegistrationService.cs`:
+```csharp
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Mpt.Extensions.Sdk.Hosting;
+
+namespace Mpt.Extensions.Sdk.Registration;
+
+/// <summary>Registers the extension instance with the platform and persists the returned identity.</summary>
+public sealed class RegistrationService
+{
+    private static readonly JsonSerializerOptions Json = new() { DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull };
+
+    private readonly HttpClient _http;
+    private readonly ExtensionOptions _options;
+    private readonly IdentityStore _identity;
+
+    public RegistrationService(HttpClient http, ExtensionOptions options, IdentityStore identity)
+    {
+        _http = http;
+        _options = options;
+        _identity = identity;
+    }
+
+    public async Task RegisterAsync(MetaConfig meta, CancellationToken ct = default)
+    {
+        var freshChannel = !_identity.MatchesExtension(_options.ExtensionId);
+        var payload = new RegistrationPayload
+        {
+            ExternalId = _options.ExternalId,
+            Version = _options.Version,
+            Meta = meta,
+            Channel = freshChannel ? new { } : null,
+        };
+
+        using var req = new HttpRequestMessage(HttpMethod.Post,
+            $"/public/v1/integration/extensions/{_options.ExtensionId}/instances")
+        {
+            Content = new StringContent(JsonSerializer.Serialize(payload, Json), Encoding.UTF8, "application/json"),
+        };
+        req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _options.ExtensionApiKey ?? "");
+
+        using var res = await _http.SendAsync(req, ct);
+        var body = await res.Content.ReadAsStringAsync(ct);
+        if (!res.IsSuccessStatusCode)
+            throw new InvalidOperationException(
+                $"Extension registration failed ({(int)res.StatusCode}): {body}");
+
+        using var doc = JsonDocument.Parse(string.IsNullOrWhiteSpace(body) ? "{}" : body);
+        if (doc.RootElement.TryGetProperty("channel", out var channel) &&
+            channel.TryGetProperty("identity", out var identity) &&
+            identity.ValueKind == JsonValueKind.Object)
+        {
+            _identity.Save(identity);
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests — expect pass**
+
+```bash
+dotnet test --filter FullyQualifiedName~RegistrationServiceTests
+```
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat: registration service (POST instances, persist identity)"
+```
+
+### Task D10: Registration hosted service + wire into the host builder
+
+**Files:**
+- Create: `$DST/src/Mpt.Extensions.Sdk/Registration/RegistrationHostedService.cs`
+- Modify: `$DST/src/Mpt.Extensions.Sdk/Hosting/ExtensionHostBuilder.cs`
+- Test: `$DST/tests/Mpt.Extensions.Sdk.Tests/RegistrationHostedServiceTests.cs`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `$DST/tests/Mpt.Extensions.Sdk.Tests/RegistrationHostedServiceTests.cs`:
+```csharp
+using Mpt.Extensions.Sdk.Registration;
+
+namespace Mpt.Extensions.Sdk.Tests;
+
+public class RegistrationHostedServiceTests
+{
+    [Fact]
+    public async Task StartAsync_does_nothing_in_local_mode()
+    {
+        var called = false;
+        var svc = new RegistrationHostedService(
+            register: _ => { called = true; return Task.CompletedTask; },
+            platformMode: false);
+
+        await svc.StartAsync(CancellationToken.None);
+
+        Assert.False(called); // local mode skips registration (like uvicorn vs ziticorn)
+    }
+
+    [Fact]
+    public async Task StartAsync_registers_in_platform_mode()
+    {
+        var called = false;
+        var svc = new RegistrationHostedService(
+            register: _ => { called = true; return Task.CompletedTask; },
+            platformMode: true);
+
+        await svc.StartAsync(CancellationToken.None);
+
+        Assert.True(called);
+    }
+}
+```
+
+- [ ] **Step 2: Run it — expect failure**
+
+```bash
+dotnet test --filter FullyQualifiedName~RegistrationHostedServiceTests
+```
+Expected: FAIL — `RegistrationHostedService` does not exist.
+
+- [ ] **Step 3: Implement**
+
+Create `$DST/src/Mpt.Extensions.Sdk/Registration/RegistrationHostedService.cs`:
+```csharp
+using Microsoft.Extensions.Hosting;
+
+namespace Mpt.Extensions.Sdk.Registration;
+
+/// <summary>Runs instance registration on startup in platform mode; a no-op locally.</summary>
+public sealed class RegistrationHostedService : IHostedService
+{
+    private readonly Func<CancellationToken, Task> _register;
+    private readonly bool _platformMode;
+
+    public RegistrationHostedService(Func<CancellationToken, Task> register, bool platformMode)
+    {
+        _register = register;
+        _platformMode = platformMode;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken) =>
+        _platformMode ? _register(cancellationToken) : Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+```
+
+- [ ] **Step 4: Run the tests — expect pass**
+
+```bash
+dotnet test --filter FullyQualifiedName~RegistrationHostedServiceTests
+```
+Expected: PASS.
+
+- [ ] **Step 5: Wire it into `ExtensionHostBuilder`**
+
+In `$DST/src/Mpt.Extensions.Sdk/Hosting/ExtensionHostBuilder.cs`, after building the manifest (both the generated and reflection branches produce one), register the hosted service. Platform mode is on when an identity/platform URL is configured and `SDK_LOCAL` is not set; expose it as a simple flag:
+```csharp
+var platformMode = !string.Equals(builder.Configuration["SDK_MODE"], "local", StringComparison.OrdinalIgnoreCase)
+    && !string.IsNullOrEmpty(builder.Configuration["SDK_EXTENSION_URL"]);
+
+builder.Services.AddHostedService(sp =>
+{
+    var options = sp.GetRequiredService<ExtensionOptions>();
+    var http = sp.GetRequiredService<IHttpClientFactory>().CreateClient("mpt-tokens");
+    var meta = MetaBuilder.Build(currentManifest); // the ExtensionManifest used to map routes
+    var registration = new RegistrationService(http, options, new IdentityStore(options.IdentityFilePath));
+    return new RegistrationHostedService(ct => registration.RegisterAsync(meta, ct), platformMode);
+});
+```
+Make sure `currentManifest` refers to the `ExtensionManifest` available in scope (the reflection branch has `manifest`; for the generated branch, build a `MetaConfig` from `GeneratedHandlerRegistry` via a small `MetaBuilder.FromGenerated()` overload, or reuse `ManifestJson.FromGenerated()` data). If the generated branch lacks a manifest object, add a `MetaBuilder.Build` overload that reads `GeneratedHandlerRegistry.Events`/`.ApiEndpoints`. Keep both branches registering the hosted service.
+
+- [ ] **Step 6: Build and run the full suite**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+dotnet test
+```
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "feat: registration hosted service wired into host builder"
+```
+
+---
+
+## Phase E — Local end-to-end smoke
+
+### Task E1: Minimal sample extension that builds and serves locally
+
+**Files:**
+- Create: `$DST/samples/Sample.LocalExtension/Sample.LocalExtension.csproj`
+- Create: `$DST/samples/Sample.LocalExtension/Program.cs`
+- Create: `$DST/samples/Sample.LocalExtension/OrderHandlers.cs`
+- Modify: `$DST/Mpt.Extensions.Sdk.slnx` (add the sample)
+
+- [ ] **Step 1: Create the sample project**
+
+Create `$DST/samples/Sample.LocalExtension/Sample.LocalExtension.csproj`:
+```xml
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Mpt.Extensions.Sdk\Mpt.Extensions.Sdk.csproj" />
+  </ItemGroup>
+</Project>
+```
+
+- [ ] **Step 2: Create the handler and program**
+
+Create `$DST/samples/Sample.LocalExtension/OrderHandlers.cs`:
+```csharp
+using Mpt.Extensions.Sdk.Attributes;
+using Mpt.Extensions.Sdk.Contexts;
+using Mpt.Extensions.Sdk.Events;
+
+namespace Sample.LocalExtension;
+
+public class OrderHandlers
+{
+    [EventHandler(Event = "order.created", Path = "/events/order-created")]
+    public Task<EventResponse> OnCreated(OrderContext ctx)
+    {
+        ctx.Logger.LogInformation("Received order {OrderId}", ctx.OrderId);
+        return Task.FromResult(EventResponse.Ok());
+    }
+}
+```
+
+Create `$DST/samples/Sample.LocalExtension/Program.cs`:
+```csharp
+using Microsoft.AspNetCore.Builder;
+using Mpt.Extensions.Sdk.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+builder.Configuration["SDK_MODE"] = "local"; // skip registration/Ziti for the smoke test
+var app = ExtensionHostBuilder.Build(builder);
+app.Run();
+```
+
+- [ ] **Step 3: Add the sample to the solution**
+
+Add this line inside a new `<Folder Name="/samples/">` element in `$DST/Mpt.Extensions.Sdk.slnx`:
+```xml
+  <Folder Name="/samples/">
+    <Project Path="samples/Sample.LocalExtension/Sample.LocalExtension.csproj" />
+  </Folder>
+```
+
+- [ ] **Step 4: Build the whole solution**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+dotnet build
+```
+Expected: `Build succeeded` for all projects including the sample.
+
+- [ ] **Step 5: Run the sample and hit health + an event**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+dotnet run --project samples/Sample.LocalExtension --urls http://127.0.0.1:8900 &
+sleep 5
+curl -s http://127.0.0.1:8900/__health
+echo
+curl -s http://127.0.0.1:8900/__manifest
+echo
+# Event with a decode-only bearer (accountId claim); base64url of {"https://claims.softwareone.com/accountId":"ACC-1","exp":<future>}
+```
+Expected: `/__health` returns `{"status":"ok"}`; `/__manifest` lists the `order.created` route. Stop the background process afterward (`kill %1`). A 401 on the event without a bearer is expected and acceptable for this smoke test; the unit tests already cover the authenticated path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "test: local sample extension end-to-end smoke"
+```
+
+---
+
+## Self-review notes (already applied)
+
+- **Spec coverage:** Registration (D7–D10), native ingress auth (D1–D2), account tokens (D3), direct generic Marketplace client (D4), configurable serialization (C1), meta block (D8), net8 retarget (A1/B), drop bridge (ports exclude `bridge/`, egress files removed in B2). Ziti transport and the Abstractions/Ziti package split are explicitly deferred to Plan 2; the POC port to Plan 3.
+- **`meta.yaml` file:** Plan 1 generates the registration `meta` **object** (required for registration). Writing the `meta.yaml` **file** to disk (tooling/local inspection) is deferred — it needs a YAML serializer (e.g. YamlDotNet) and is not required for the platform handshake, which takes `meta` as JSON in the POST. Add it in Plan 2 alongside Ziti packaging if needed.
+- **Adapt-to-ported-types reminders:** Tasks D6 and D8 depend on the exact shapes of the ported `HandlerServices`, `ExtensionManifest`, `RouteDescriptor`, and `MarketplaceApiException`. Each such step says to read the ported type and align names rather than guess — do that before writing the code in those steps.
+
+---
+
+## Execution handoff
+
+After this plan is approved, Plans 2 (Ziti transport spike + package split) and 3 (product-hub-extension port) follow as separate documents.

--- a/docs/superpowers/plans/2026-06-19-dotnet-sdk-plan2-ziti-transport.md
+++ b/docs/superpowers/plans/2026-06-19-dotnet-sdk-plan2-ziti-transport.md
@@ -15,7 +15,13 @@
 
 **Working directory:** `C:\repos\mpt-extension-sdk-dotnet` (`$DST`). Source-of-truth for the SDK sample to adapt: the openziti GitHub repo (fetch raw files). 69 tests currently pass; solution `Mpt.Extensions.Sdk.sln`.
 
-**OPEN QUESTION to resolve before/at Task 4 (ask the platform/Ziti team):** the exact **bind service name** the extension must bind. Evidence: the identity's `mrok.tags.mrok-service` equals the extension id (e.g. `ext-5034-5001`). Default assumption in this plan: bind service name = `SDK_EXTENSION_ID` (lowercased), overridable via `SDK_ZITI_SERVICE`. Confirm and adjust Task 4 if different.
+**Bind service name — RESOLVED from the Python `mrok` source (v0.9.7, `mrok/proxy/ziticorn.py`).** The Python agent does, verbatim:
+```python
+ctx, err = openziti.load(str(identity_file), timeout=...)   # load the identity file as-is (mrok key included)
+sock = ctx.bind(identity.mrok.extension)                    # bind service = identity.mrok.extension
+sock.listen(backlog)                                        # then listen; uvicorn serves on this socket
+```
+So the **bind service name = the `mrok.extension` field inside the identity file** (e.g. `ext-5034-5001`) — read it from the loaded identity, not from a separate config value. `SDK_ZITI_SERVICE` remains an optional override. Also: `openziti.load` is given the **whole identity file unmodified** (the `mrok` key is ignored by ziti-sdk-c), and `ctx.bind` uses the **default terminator** (none passed) — mirror both in .NET (the `mrok`-strip step is optional safety; pass an empty/null terminator to `API.Bind`).
 
 **Testing reality:** A true end-to-end bind requires a live Ziti controller + a valid enrolled identity (the POC identity points at the real `api.ziti.s1.show` — do NOT bind against production from CI). Automated tests therefore cover the **identity mapper**, **DI/options wiring**, and the **TCP-fallback path** of the listener factory. The live overlay bind is validated by a **manual/deployment smoke** (documented), not CI.
 
@@ -144,8 +150,9 @@ public class ZitiIdentityTests
     }
 
     [Fact]
-    public void ServiceNameFromMrok_returns_mrok_service_tag()
+    public void ServiceNameFromMrok_returns_mrok_extension()
     {
+        // The Python mrok agent binds `identity.mrok.extension` — mirror that exactly.
         Assert.Equal("ext-1", ZitiIdentity.ServiceNameFromMrok(Persisted));
     }
 
@@ -192,15 +199,17 @@ public static class ZitiIdentity
         File.WriteAllText(outPath, node.ToJsonString());
     }
 
-    /// <summary>The bind service name carried in <c>mrok.tags.mrok-service</c>, or null if absent.</summary>
+    /// <summary>
+    /// The bind service name, taken from <c>mrok.extension</c> — exactly what the Python
+    /// mrok agent binds (<c>ctx.bind(identity.mrok.extension)</c>). Null if absent.
+    /// </summary>
     public static string? ServiceNameFromMrok(string persistedIdentityJson)
     {
         using var doc = JsonDocument.Parse(persistedIdentityJson);
         if (doc.RootElement.TryGetProperty("mrok", out var mrok) &&
-            mrok.TryGetProperty("tags", out var tags) &&
-            tags.TryGetProperty("mrok-service", out var svc))
+            mrok.TryGetProperty("extension", out var ext))
         {
-            return svc.GetString();
+            return ext.GetString();
         }
         return null;
     }
@@ -281,7 +290,7 @@ public sealed class ZitiOptions
     }
 }
 ```
-(Confirm the service-name source against the platform team — see the OPEN QUESTION. If the service is NOT the extension id, change the default here only.)
+Service-name resolution priority (authoritative source confirmed from `mrok`): `SDK_ZITI_SERVICE` override → **`ZitiIdentity.ServiceNameFromMrok(identity)` = `mrok.extension`** (what `mrok` binds) → `SDK_EXTENSION_ID` lowercased as a last-resort fallback. `ZitiOptions` here covers the config-only paths; `UseZiti` (Task 5) prefers the identity's `mrok.extension` once the identity file is read. The config default to the lowercased extension id matches the observed `mrok.extension` value, so the two agree.
 
 - [ ] **Step 4: Run, expect PASS. Step 5: Commit** `git add -A && git commit -m "feat(ziti): ZitiOptions from configuration"`
 
@@ -324,7 +333,7 @@ Expected: Build succeeded. Resolve any API drift between the sample (which may t
 - [ ] **Step 1: Implement `UseZiti()`** in `src/Mpt.Extensions.Sdk.Ziti/ZitiHostExtensions.cs`:
   - An extension `public static WebApplicationBuilder UseZiti(this WebApplicationBuilder builder)` (or `IWebHostBuilder`) that:
     1. resolves `ZitiOptions.FromConfiguration(builder.Configuration)`,
-    2. on startup (or inline before Kestrel binds), reads the persisted identity at `IdentityFilePath`, calls `ZitiIdentity.WriteZitiIdentityFile(...)` to a sibling `ziti-identity.json`, and uses `ZitiIdentity.ServiceNameFromMrok(...)` as a fallback service name if config didn't set one,
+    2. on startup (or inline before Kestrel binds), reads the persisted identity at `IdentityFilePath`, calls `ZitiIdentity.WriteZitiIdentityFile(...)` to a sibling `ziti-identity.json`, and resolves the bind service name as `SDK_ZITI_SERVICE` (if set) else `ZitiIdentity.ServiceNameFromMrok(identity)` (= `mrok.extension`, exactly what the Python `mrok` agent binds via `ctx.bind(identity.mrok.extension)`),
     3. registers the `ZitiConnectionListenerFactory` as `IConnectionListenerFactory` and configures Kestrel to listen on a `ZitiEndPoint(serviceName)` (model the `UseZitiTransport` wiring from the sample's `ServiceCollectionExtensions.cs`).
   - This must compose with the core SDK: the consumer writes `ExtensionHostBuilder.Build(builder)` and, for platform deployment, also calls `builder.UseZiti()` (order per what the wiring requires — document it).
   - IMPORTANT ordering vs registration: the identity file must exist before Ziti binds. The core SDK's `RegistrationHostedService` writes it on startup in platform mode. Ensure `UseZiti` reads the identity at the right time (e.g. resolve/transform lazily at first bind, or document that registration must complete first). If a startup-ordering conflict exists, have `UseZiti` perform registration-or-wait, or expose an explicit `await app.RegisterAsync()` the consumer calls before `RunAsync()`. Choose the simplest correct ordering and document it in `docs/ziti-deployment-smoke.md`.

--- a/docs/superpowers/plans/2026-06-19-dotnet-sdk-plan2-ziti-transport.md
+++ b/docs/superpowers/plans/2026-06-19-dotnet-sdk-plan2-ziti-transport.md
@@ -1,0 +1,389 @@
+# Pure-.NET Extension SDK — Plan 2: OpenZiti Transport
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add a `Mpt.Extensions.Sdk.Ziti` library that serves the extension host over the OpenZiti overlay using the persisted platform identity — the .NET equivalent of the Python `ziticorn` — so platform-mode extensions receive events/API calls over Ziti instead of plain TCP.
+
+**Architecture:** Isolate the native `OpenZiti.NET` dependency in its own package. Adapt the upstream reference `ZitiConnectionListenerFactory` (a Kestrel `IConnectionListenerFactory`) + `UseZitiTransport` from the openziti/ziti-sdk-csharp `OpenZiti.NET.Samples/src/Kestrel` sample. Map the persisted `channel.identity` to a ziti-loadable identity file and bind the extension's service. Keep local mode on plain Kestrel; opt into Ziti only in platform mode.
+
+**Tech Stack:** .NET 8, `OpenZiti.NET` `1.0.26159.2780` (+ `OpenZiti.NET.native`), ASP.NET Core Kestrel transport abstractions (`Microsoft.AspNetCore.Connections`), `SocketConnectionContextFactory`.
+
+**Pre-resolved by the Plan 2 spike (2026-06-19):**
+- B1 (app-embedded) is the chosen approach; the upstream sample already implements the hard part (accepted `ZitiSocket` → real `Socket` → `SocketConnectionContextFactory.Create` → Kestrel `ConnectionContext`). Sample dir: https://github.com/openziti/ziti-sdk-csharp/tree/main/OpenZiti.NET.Samples/src/Kestrel
+- `channel.identity` is a standard **enrolled** ziti identity JSON (`ztAPI`, `id.{key,cert,ca}`, `enableHa`) + an extra non-ziti `mrok` key. No enrollment flow needed.
+- Key APIs: `new ZitiContext(string identityFile)`; `API.Bind/Listen/Accept`; `ZitiSocket.ToSocket()`; host extension `UseZitiTransport(identity, service)`.
+
+**Working directory:** `C:\repos\mpt-extension-sdk-dotnet` (`$DST`). Source-of-truth for the SDK sample to adapt: the openziti GitHub repo (fetch raw files). 69 tests currently pass; solution `Mpt.Extensions.Sdk.sln`.
+
+**OPEN QUESTION to resolve before/at Task 4 (ask the platform/Ziti team):** the exact **bind service name** the extension must bind. Evidence: the identity's `mrok.tags.mrok-service` equals the extension id (e.g. `ext-5034-5001`). Default assumption in this plan: bind service name = `SDK_EXTENSION_ID` (lowercased), overridable via `SDK_ZITI_SERVICE`. Confirm and adjust Task 4 if different.
+
+**Testing reality:** A true end-to-end bind requires a live Ziti controller + a valid enrolled identity (the POC identity points at the real `api.ziti.s1.show` — do NOT bind against production from CI). Automated tests therefore cover the **identity mapper**, **DI/options wiring**, and the **TCP-fallback path** of the listener factory. The live overlay bind is validated by a **manual/deployment smoke** (documented), not CI.
+
+---
+
+## File structure (end state of Plan 2)
+
+```
+$DST/
+  src/Mpt.Extensions.Sdk.Ziti/
+    Mpt.Extensions.Sdk.Ziti.csproj         # net8.0; refs OpenZiti.NET + the core SDK
+    ZitiEndPoint.cs                         # marker EndPoint carrying the service name
+    ZitiConnectionListenerFactory.cs        # adapted from the upstream sample
+    ZitiConnectionListener.cs               # accept-loop -> Channel -> SocketConnectionContextFactory
+    ZitiIdentity.cs                         # map persisted channel.identity -> ziti identity file
+    ZitiOptions.cs                          # identity path + service name (from config)
+    ZitiHostExtensions.cs                   # UseZitiTransport(...) / UseZiti() host wiring
+  tests/Mpt.Extensions.Sdk.Ziti.Tests/
+    Mpt.Extensions.Sdk.Ziti.Tests.csproj
+    ZitiIdentityTests.cs
+    ZitiOptionsTests.cs
+    ZitiConnectionListenerFactoryTests.cs   # TCP-fallback path only
+  docs/ziti-deployment-smoke.md             # manual end-to-end validation steps
+```
+
+`Mpt.Extensions.Sdk.Ziti` depends on `Mpt.Extensions.Sdk` (Hosting) + `OpenZiti.NET`. The core SDK keeps NO dependency on `OpenZiti.NET` (the native dep stays isolated here).
+
+---
+
+## Task 1: Scaffold the Ziti project and confirm the native package restores on net8.0
+
+**Files:** Create `src/Mpt.Extensions.Sdk.Ziti/Mpt.Extensions.Sdk.Ziti.csproj`; modify `Mpt.Extensions.Sdk.sln`.
+
+- [ ] **Step 1: Create the project**
+
+`src/Mpt.Extensions.Sdk.Ziti/Mpt.Extensions.Sdk.Ziti.csproj`:
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <IsPackable>true</IsPackable>
+    <PackageId>Mpt.Extensions.Sdk.Ziti</PackageId>
+    <Title>MPT Extension SDK — OpenZiti transport</Title>
+    <Description>Serve a SoftwareONE Marketplace extension over the OpenZiti overlay (the .NET ziticorn equivalent).</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="OpenZiti.NET" Version="1.0.26159.2780" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Mpt.Extensions.Sdk\Mpt.Extensions.Sdk.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Mpt.Extensions.Sdk.Ziti.Tests" />
+  </ItemGroup>
+</Project>
+```
+
+- [ ] **Step 2: Add to the solution**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+dotnet sln Mpt.Extensions.Sdk.sln add src/Mpt.Extensions.Sdk.Ziti/Mpt.Extensions.Sdk.Ziti.csproj
+```
+
+- [ ] **Step 3: Add a placeholder type so the project compiles, then restore/build**
+
+Create `src/Mpt.Extensions.Sdk.Ziti/ZitiOptions.cs` with a temporary empty `namespace Mpt.Extensions.Sdk.Ziti; internal sealed class ZitiOptions { }` (replaced in Task 3), then:
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+dotnet build src/Mpt.Extensions.Sdk.Ziti/Mpt.Extensions.Sdk.Ziti.csproj
+```
+Expected: restore pulls `OpenZiti.NET` + `OpenZiti.NET.native`; **Build succeeded**. If `OpenZiti.NET` fails to resolve on `nuget.org`, confirm the version exists (the spike found `1.0.26159.2780`, published 2026-06-08); pin to the latest available `1.0.*` shown on https://www.nuget.org/packages/OpenZiti.NET . If the native package warns about RID assets, that is expected at pack time, not build.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "feat(ziti): scaffold OpenZiti transport project (net8.0)"
+```
+
+## Task 2: Identity mapping (TDD)
+
+**Files:** Create `src/Mpt.Extensions.Sdk.Ziti/ZitiIdentity.cs`; test `tests/Mpt.Extensions.Sdk.Ziti.Tests/ZitiIdentityTests.cs` (+ the test csproj — see Step 0).
+
+- [ ] **Step 0: Create the Ziti test project** (mirror `Mpt.Extensions.Sdk.Tests.csproj`: same package versions — `Microsoft.NET.Test.Sdk` 17.12.0, `xunit` 2.9.2, `xunit.runner.visualstudio` 3.0.0, `coverlet.collector` 6.0.4, `<Using Include="Xunit" />`, `FrameworkReference Microsoft.AspNetCore.App`), with a `ProjectReference` to `..\..\src\Mpt.Extensions.Sdk.Ziti\Mpt.Extensions.Sdk.Ziti.csproj`. Add it to the solution with `dotnet sln add`.
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/Mpt.Extensions.Sdk.Ziti.Tests/ZitiIdentityTests.cs`:
+```csharp
+using System.Text.Json;
+using Mpt.Extensions.Sdk.Ziti;
+
+namespace Mpt.Extensions.Sdk.Ziti.Tests;
+
+public class ZitiIdentityTests
+{
+    // A realistic persisted channel.identity: standard ziti fields + the extra non-ziti "mrok" key.
+    private const string Persisted = """
+    {
+      "ztAPI": "https://api.ziti.s1.show/edge/client/v1",
+      "ztAPIs": null,
+      "configTypes": null,
+      "id": { "key": "pem:KEY", "cert": "pem:CERT", "ca": "pem:CA" },
+      "enableHa": false,
+      "mrok": { "extension": "ext-1", "instance": "ins-1", "tags": { "mrok-service": "ext-1" } }
+    }
+    """;
+
+    [Fact]
+    public void WriteZitiIdentityFile_strips_mrok_and_keeps_ziti_fields()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"ziti-{Guid.NewGuid():N}");
+        var outPath = Path.Combine(dir, "ziti-identity.json");
+
+        ZitiIdentity.WriteZitiIdentityFile(Persisted, outPath);
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(outPath));
+        var root = doc.RootElement;
+        Assert.Equal("https://api.ziti.s1.show/edge/client/v1", root.GetProperty("ztAPI").GetString());
+        Assert.Equal("pem:CERT", root.GetProperty("id").GetProperty("cert").GetString());
+        Assert.False(root.TryGetProperty("mrok", out _)); // non-ziti metadata removed
+    }
+
+    [Fact]
+    public void ServiceNameFromMrok_returns_mrok_service_tag()
+    {
+        Assert.Equal("ext-1", ZitiIdentity.ServiceNameFromMrok(Persisted));
+    }
+
+    [Fact]
+    public void ServiceNameFromMrok_returns_null_when_absent()
+    {
+        Assert.Null(ZitiIdentity.ServiceNameFromMrok("{\"ztAPI\":\"x\"}"));
+    }
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet' && dotnet test tests/Mpt.Extensions.Sdk.Ziti.Tests/Mpt.Extensions.Sdk.Ziti.Tests.csproj --filter FullyQualifiedName~ZitiIdentityTests
+```
+
+- [ ] **Step 3: Implement**
+
+`src/Mpt.Extensions.Sdk.Ziti/ZitiIdentity.cs`:
+```csharp
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Mpt.Extensions.Sdk.Ziti;
+
+/// <summary>
+/// Bridges the persisted platform identity (<c>channel.identity</c>) to a ziti-loadable
+/// identity file. The persisted JSON is already a standard enrolled ziti identity plus an
+/// extra non-ziti <c>mrok</c> metadata key, which we strip before handing it to the loader.
+/// </summary>
+public static class ZitiIdentity
+{
+    /// <summary>Write a ziti-ready identity file (mrok stripped) to <paramref name="outPath"/>.</summary>
+    public static void WriteZitiIdentityFile(string persistedIdentityJson, string outPath)
+    {
+        var node = JsonNode.Parse(persistedIdentityJson)?.AsObject()
+            ?? throw new InvalidOperationException("Identity JSON is not an object.");
+        node.Remove("mrok");
+
+        var dir = Path.GetDirectoryName(outPath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+        File.WriteAllText(outPath, node.ToJsonString());
+    }
+
+    /// <summary>The bind service name carried in <c>mrok.tags.mrok-service</c>, or null if absent.</summary>
+    public static string? ServiceNameFromMrok(string persistedIdentityJson)
+    {
+        using var doc = JsonDocument.Parse(persistedIdentityJson);
+        if (doc.RootElement.TryGetProperty("mrok", out var mrok) &&
+            mrok.TryGetProperty("tags", out var tags) &&
+            tags.TryGetProperty("mrok-service", out var svc))
+        {
+            return svc.GetString();
+        }
+        return null;
+    }
+}
+```
+
+- [ ] **Step 4: Run, expect PASS. Step 5: Commit** `git add -A && git commit -m "feat(ziti): map persisted identity to ziti identity file"`
+
+## Task 3: Ziti options (TDD)
+
+**Files:** Replace `src/Mpt.Extensions.Sdk.Ziti/ZitiOptions.cs`; test `tests/Mpt.Extensions.Sdk.Ziti.Tests/ZitiOptionsTests.cs`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Microsoft.Extensions.Configuration;
+using Mpt.Extensions.Sdk.Ziti;
+
+namespace Mpt.Extensions.Sdk.Ziti.Tests;
+
+public class ZitiOptionsTests
+{
+    [Fact]
+    public void FromConfiguration_defaults_service_to_extension_id_lowercased()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["SDK_EXTENSION_ID"] = "EXT-5034-5001",
+            ["SDK_IDENTITY_FILE_PATH"] = "./identity/identity.json",
+        }).Build();
+
+        var o = ZitiOptions.FromConfiguration(config);
+
+        Assert.Equal("ext-5034-5001", o.ServiceName);
+        Assert.Equal("./identity/identity.json", o.IdentityFilePath);
+    }
+
+    [Fact]
+    public void FromConfiguration_honors_explicit_service_override()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["SDK_EXTENSION_ID"] = "EXT-1",
+            ["SDK_ZITI_SERVICE"] = "custom-svc",
+        }).Build();
+
+        Assert.Equal("custom-svc", ZitiOptions.FromConfiguration(config).ServiceName);
+    }
+}
+```
+
+- [ ] **Step 2: Run, expect FAIL. Step 3: Implement** `src/Mpt.Extensions.Sdk.Ziti/ZitiOptions.cs`:
+```csharp
+using Microsoft.Extensions.Configuration;
+
+namespace Mpt.Extensions.Sdk.Ziti;
+
+/// <summary>Ziti transport options resolved from configuration.</summary>
+public sealed class ZitiOptions
+{
+    /// <summary>Path to the persisted platform identity (same file the registration step writes).</summary>
+    public required string IdentityFilePath { get; init; }
+
+    /// <summary>The ziti service the extension binds to receive inbound traffic.</summary>
+    public required string ServiceName { get; init; }
+
+    public static ZitiOptions FromConfiguration(IConfiguration config)
+    {
+        var extensionId = config["SDK_EXTENSION_ID"] ?? "";
+        var service = config["SDK_ZITI_SERVICE"];
+        if (string.IsNullOrEmpty(service))
+            service = extensionId.ToLowerInvariant();
+        return new ZitiOptions
+        {
+            IdentityFilePath = config["SDK_IDENTITY_FILE_PATH"] ?? "identity/identity.json",
+            ServiceName = service,
+        };
+    }
+}
+```
+(Confirm the service-name source against the platform team — see the OPEN QUESTION. If the service is NOT the extension id, change the default here only.)
+
+- [ ] **Step 4: Run, expect PASS. Step 5: Commit** `git add -A && git commit -m "feat(ziti): ZitiOptions from configuration"`
+
+## Task 4: Vendor + adapt the Kestrel transport from the upstream sample
+
+**Files:** Create `ZitiEndPoint.cs`, `ZitiConnectionListenerFactory.cs`, `ZitiConnectionListener.cs`.
+
+> Do NOT hand-invent the OpenZiti API calls. FETCH the upstream sample source and adapt it. These files are the reference implementation; copy their structure and adjust namespaces/types to our project.
+
+- [ ] **Step 1: Fetch the upstream sample sources**
+
+Retrieve (WebFetch on the raw GitHub URLs under `OpenZiti.NET.Samples/src/Kestrel/`):
+- `ZitiConnectionListenerFactory.cs`
+- `ServiceCollectionExtensions.cs` (for the `UseZitiTransport` wiring — used in Task 5)
+- `KestrelSample.cs` (shows end-to-end usage)
+Base: https://raw.githubusercontent.com/openziti/ziti-sdk-csharp/main/OpenZiti.NET.Samples/src/Kestrel/
+Read them to learn the exact `ZitiSocket`/`API.Bind/Listen/Accept` usage, the `ZitiEndPoint`, the accept-loop + `Channel`, and the `SocketConnectionContextFactory.Create(socket)` call.
+
+- [ ] **Step 2: Vendor `ZitiEndPoint.cs`** — a `System.Net.EndPoint` subclass carrying the bind service name (copy from the sample; namespace `Mpt.Extensions.Sdk.Ziti`).
+
+- [ ] **Step 3: Vendor `ZitiConnectionListenerFactory.cs` + `ZitiConnectionListener.cs`** — adapt the sample's `IConnectionListenerFactory`/`IConnectionListener`:
+  - `BindAsync`: when the `EndPoint` is a `ZitiEndPoint`, create `ZitiSocket(SocketType.Stream)`, load the `ZitiContext` from the mapped identity file (produced in Task 2 / wired in Task 5), `API.Bind(socket, ctx, serviceName, terminator)`, `API.Listen(socket, backlog)`, return the listener; otherwise fall back to the default TCP `SocketTransportFactory` behavior (keep the fallback — it makes local/test usage and unit testing possible).
+  - The listener runs a background accept loop: `Poll(SelectRead)` → `API.Accept(...)` → write `(ZitiSocket, caller)` to an `UnboundedChannel`; `AcceptAsync` reads the channel, calls `client.ToSocket()`, and returns `SocketConnectionContextFactory.Create(socket)` as the `ConnectionContext`.
+  - Honour `CancellationToken`/`UnbindAsync`/`DisposeAsync` with a bounded shutdown (the sample uses ~5s).
+  - Keep the OpenZiti context init (`API.InitializeZiti(...)`/run-loop) exactly as the sample does it.
+
+- [ ] **Step 4: Build**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet' && dotnet build src/Mpt.Extensions.Sdk.Ziti/Mpt.Extensions.Sdk.Ziti.csproj
+```
+Expected: Build succeeded. Resolve any API drift between the sample (which may target a newer SDK) and `1.0.26159.2780` by reading the installed package's types (e.g. via the `dotnet-inspect` skill or the `OpenZiti.NET` source on GitHub) and adjusting calls.
+
+- [ ] **Step 5: Commit** `git add -A && git commit -m "feat(ziti): vendor + adapt Kestrel IConnectionListenerFactory over OpenZiti"`
+
+## Task 5: Host wiring — `UseZiti()` (TDD where possible)
+
+**Files:** Create `ZitiHostExtensions.cs`; test `tests/Mpt.Extensions.Sdk.Ziti.Tests/ZitiConnectionListenerFactoryTests.cs` (TCP-fallback path).
+
+- [ ] **Step 1: Implement `UseZiti()`** in `src/Mpt.Extensions.Sdk.Ziti/ZitiHostExtensions.cs`:
+  - An extension `public static WebApplicationBuilder UseZiti(this WebApplicationBuilder builder)` (or `IWebHostBuilder`) that:
+    1. resolves `ZitiOptions.FromConfiguration(builder.Configuration)`,
+    2. on startup (or inline before Kestrel binds), reads the persisted identity at `IdentityFilePath`, calls `ZitiIdentity.WriteZitiIdentityFile(...)` to a sibling `ziti-identity.json`, and uses `ZitiIdentity.ServiceNameFromMrok(...)` as a fallback service name if config didn't set one,
+    3. registers the `ZitiConnectionListenerFactory` as `IConnectionListenerFactory` and configures Kestrel to listen on a `ZitiEndPoint(serviceName)` (model the `UseZitiTransport` wiring from the sample's `ServiceCollectionExtensions.cs`).
+  - This must compose with the core SDK: the consumer writes `ExtensionHostBuilder.Build(builder)` and, for platform deployment, also calls `builder.UseZiti()` (order per what the wiring requires — document it).
+  - IMPORTANT ordering vs registration: the identity file must exist before Ziti binds. The core SDK's `RegistrationHostedService` writes it on startup in platform mode. Ensure `UseZiti` reads the identity at the right time (e.g. resolve/transform lazily at first bind, or document that registration must complete first). If a startup-ordering conflict exists, have `UseZiti` perform registration-or-wait, or expose an explicit `await app.RegisterAsync()` the consumer calls before `RunAsync()`. Choose the simplest correct ordering and document it in `docs/ziti-deployment-smoke.md`.
+
+- [ ] **Step 2: Test the TCP-fallback path** (the only path testable without a live controller). `ZitiConnectionListenerFactoryTests.cs`: assert that `BindAsync` with a normal `IPEndPoint` returns a working TCP `IConnectionListener` (i.e. the factory degrades to TCP for non-Ziti endpoints), proving the factory is wired correctly and safe in local mode. If the adapted factory delegates TCP to `SocketTransportFactory`, a minimal test can bind `IPEndPoint(IPAddress.Loopback, 0)` and assert a non-null listener + `EndPoint`.
+
+- [ ] **Step 3: Build + run the Ziti test project + full solution**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+dotnet test Mpt.Extensions.Sdk.sln
+```
+Expected: all green (existing 69 + the new Ziti unit tests). The core SDK tests are unaffected (no dependency on the Ziti project).
+
+- [ ] **Step 4: Commit** `git add -A && git commit -m "feat(ziti): UseZiti() host wiring + TCP-fallback test"`
+
+## Task 6: Update the sample + document the deployment smoke
+
+**Files:** Modify `samples/Sample.LocalExtension/Program.cs` (show the platform-mode opt-in, guarded); create `docs/ziti-deployment-smoke.md`.
+
+- [ ] **Step 1: Show the opt-in in the sample (without breaking local run)**
+
+In `samples/Sample.LocalExtension/Program.cs`, demonstrate the pattern without requiring Ziti locally:
+```csharp
+using Microsoft.AspNetCore.Builder;
+using Mpt.Extensions.Sdk.Hosting;
+using Mpt.Extensions.Sdk.Ziti;
+
+var builder = WebApplication.CreateBuilder(args);
+var platform = string.Equals(builder.Configuration["SDK_MODE"], "platform", StringComparison.OrdinalIgnoreCase);
+if (platform)
+    builder.UseZiti();          // serve over the Ziti overlay using the persisted identity
+else
+    builder.Configuration["SDK_MODE"] = "local"; // local dev: plain Kestrel, skip registration
+
+var app = ExtensionHostBuilder.Build(builder);
+app.Run();
+```
+Add a `ProjectReference` to `Mpt.Extensions.Sdk.Ziti` in the sample csproj. Build the solution; confirm the sample still runs locally (plain Kestrel) exactly as in Plan 1's smoke (`/__health` → ok). Do NOT attempt a live Ziti bind here.
+
+- [ ] **Step 2: Write `docs/ziti-deployment-smoke.md`** — the manual end-to-end validation: set `SDK_MODE=platform`, `SDK_EXTENSION_ID`, `SDK_EXTENSION_API_KEY`, `SDK_EXTENSION_URL`, `MPT_API_BASE_URL`, `SDK_IDENTITY_FILE_PATH`; run; confirm registration persists the identity, the Ziti transport binds the service, and a platform-routed event reaches a handler. Note the prerequisite (a real enrolled identity + reachable controller) and that this is NOT run in CI.
+
+- [ ] **Step 3: Build + full suite + commit**
+
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+dotnet build Mpt.Extensions.Sdk.sln && dotnet test Mpt.Extensions.Sdk.sln
+git add -A && git commit -m "docs(ziti): sample opt-in + deployment smoke guide"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** the `Swo.Mpt.Extensions.Ziti` package (here `Mpt.Extensions.Sdk.Ziti`), identity mapping, B1 transport, `UseZiti()` wiring, and the local/platform split are all covered. The native dep stays isolated (core SDK unchanged). The Abstractions/Hosting/Ziti three-way split from the spec is realized as: core `Mpt.Extensions.Sdk` (authoring + hosting) + `Mpt.Extensions.Sdk.Ziti` — the Abstractions/Hosting split was deemed unnecessary for now (YAGNI; the isolation that mattered was the native Ziti dep, which this achieves).
+- **Open question (bind service name)** is flagged at the top and at Task 3/4 — resolve with the platform team; only the default in `ZitiOptions` changes if it differs.
+- **Testing honesty:** no silent claim of end-to-end coverage — the live overlay bind is a documented manual smoke (Task 6), because it needs a real controller + identity. Automated tests cover identity mapping, options, and the TCP-fallback path.
+- **API drift:** Task 4 explicitly says to adapt the sample to the pinned `OpenZiti.NET 1.0.26159.2780` API by reading the installed package types, since the sample tracks `main`.
+
+## Execution handoff
+
+After Plan 2, the SDK serves over Ziti in platform mode. Remaining future work (separate): Plan 3 — port `product-hub-extension` onto the pure-.NET SDK as the acceptance check (drop its bridge, supply its own models, validate against s1.show), which also exercises the deployment smoke.

--- a/docs/superpowers/plans/2026-06-19-dotnet-sdk-plan3-port-producthub.md
+++ b/docs/superpowers/plans/2026-06-19-dotnet-sdk-plan3-port-producthub.md
@@ -1,0 +1,212 @@
+# Pure-.NET Extension SDK — Plan 3: Migrate product-hub-extension onto the SDK
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Migrate the real `C:\repos\product-hub-extension` POC off the Python-bridge SDK onto the pure-.NET SDK (`Mpt.Extensions.Sdk` + `Mpt.Extensions.Sdk.Ziti`), proving the SDK works for a real extension (the acceptance check).
+
+**Architecture:** The new SDK preserved the authoring API, so the handler + tests need (essentially) no code change. Work = packaging and deployment wiring: pack the SDK into the POC's local feed, swap package references (drop the obsolete `Mpt.Extensions.Sdk.Marketplace`; the POC already supplies its own `ProductItem`/`ExternalIds`), add the public feeds the Ziti package's `OpenZiti.NET` dependency needs, add the `UseZiti()` platform opt-in, and replace the Python-bridge Docker/compose with a pure-.NET container.
+
+**Tech Stack:** .NET (POC stays net10.0; references net8.0 SDK packages — forward-compatible), the SDK packed as local NuGet, xUnit.
+
+**Working dirs:** `$POC` = `C:\repos\product-hub-extension` (the target; **not currently a git repo**). `$SDK` = `C:\repos\mpt-extension-sdk-dotnet` (source of the packages; 80 tests green; pinned net8 SDK).
+
+**Ground truth captured (do not re-derive):**
+- `$POC/ProductHubExtension.csproj`: net10.0; refs `Mpt.Extensions.Sdk 0.1.0-*` + `Mpt.Extensions.Sdk.Marketplace 0.1.0-*`; `DefaultItemExcludes` keeps `ProductHubExtension.Tests/**;.packages/**;identity/**` out.
+- `$POC/nuget.config`: ONLY a `local-sdk` source (`./.packages`); nuget.org intentionally omitted.
+- `$POC/Program.cs`: configures ProductHub DI, then `var app = ExtensionHostBuilder.Build(builder); app.Run();`.
+- `$POC/Handlers/ProductItemCreatedHandler.cs`: `[EventHandler(Event="platform.catalog.productItem.created", Condition="eq(product.id,PRD-7811-7846)")]`, uses `ctx.Marketplace.GetAsync<ProductItem>` / `PutAsync<ProductItem>` and returns `EventResponse.Ok/Delay`.
+- `$POC/Models/ProductItem.cs`: own `ProductItem` + `ExternalIds` (model-agnostic — keep).
+- `$POC/ProductHubExtension.Tests/*`: handler tests use `new HandlerServices(IServiceProvider, IMarketplaceClient, ILogger)`, `new EventContext(evt, new AuthContext(), services, default)`, `MarketplaceApiException(int,string)` — all match the new SDK's public API. Should pass unchanged.
+- New SDK package version: `0.1.0-alpha.1` (from `$SDK/Directory.Build.props`) — matches the POC's `0.1.0-*` wildcard.
+- `$POC/Dockerfile`: builds on the bridge base image (`ghcr.io/softwareone-platform/mpt-extension-dotnet-sdk:latest`, Python bridge + .NET) and sets `BRIDGE_CSHARP_CMD`. `$POC/docker-compose.yaml` + `docker-compose.platform.yaml`: bridge-based.
+
+---
+
+## Task 1: Safety net + reference the new SDK packages, build + tests green
+
+This is the acceptance check: by the end, the POC builds and its tests pass against the pure-.NET SDK.
+
+- [ ] **Step 1: Initialise git in the POC as a safety net (it is not under version control)**
+
+```bash
+cd 'C:/repos/product-hub-extension'
+git init -b main
+git add -A
+git commit -m "chore: baseline before pure-.NET SDK migration"
+```
+(If `git init` reports it is already a repo, skip — just commit a baseline.)
+
+- [ ] **Step 2: Pack the new SDK into the POC's local feed**
+
+Pack the two packable SDK projects (Release) straight into the POC's `./.packages`:
+```bash
+cd 'C:/repos/mpt-extension-sdk-dotnet'
+dotnet pack Mpt.Extensions.Sdk.sln -c Release -o 'C:/repos/product-hub-extension/.packages'
+```
+Expected: produces `Mpt.Extensions.Sdk.0.1.0-alpha.1.nupkg` and `Mpt.Extensions.Sdk.Ziti.0.1.0-alpha.1.nupkg` in `$POC/.packages`. (The SourceGen project is bundled as the analyzer inside `Mpt.Extensions.Sdk` via its `EnsureAnalyzerBundled` target; pack builds it first. Test/sample projects are `IsPackable=false` and are not packed.) If pack fails on the analyzer-bundled check, run `dotnet build Mpt.Extensions.Sdk.sln -c Release` first, then re-run pack.
+
+Then remove any stale old packages from the POC feed so the wildcard resolves the fresh ones:
+```bash
+cd 'C:/repos/product-hub-extension/.packages'
+ls *.nupkg
+# delete any Mpt.Extensions.Sdk.Marketplace*.nupkg and any older Mpt.Extensions.Sdk*/Ziti* versions if present
+rm -f Mpt.Extensions.Sdk.Marketplace*.nupkg
+```
+
+- [ ] **Step 3: Add the public feeds the Ziti package needs**
+
+`Mpt.Extensions.Sdk.Ziti` depends on `OpenZiti.NET`, which is NOT in the local feed. Overwrite `$POC/nuget.config` to add nuget.org + PyraCloud while keeping the local feed (this environment can reach both — the SDK itself restored `OpenZiti.NET` here):
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="local-sdk" value="./.packages" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="PyraCloud" value="https://pkgs.dev.azure.com/softwareone-pc/_packaging/PyraCloud/nuget/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+- [ ] **Step 4: Swap package references in the POC csproj**
+
+Edit `$POC/ProductHubExtension.csproj` ItemGroup: REMOVE the `Mpt.Extensions.Sdk.Marketplace` reference (the POC uses its own `ProductItem`/`ExternalIds`), KEEP `Mpt.Extensions.Sdk`, ADD `Mpt.Extensions.Sdk.Ziti`:
+```xml
+  <ItemGroup>
+    <PackageReference Include="Mpt.Extensions.Sdk" Version="0.1.0-*" />
+    <PackageReference Include="Mpt.Extensions.Sdk.Ziti" Version="0.1.0-*" />
+  </ItemGroup>
+```
+Leave `TargetFramework` net10.0 and the `DefaultItemExcludes` line unchanged.
+
+- [ ] **Step 5: Restore + build + test the POC against the new SDK**
+
+```bash
+cd 'C:/repos/product-hub-extension'
+dotnet test ProductHubExtension.Tests/ProductHubExtension.Tests.csproj
+```
+Expected: restore pulls the new SDK from `local-sdk` and `OpenZiti.NET` from nuget.org/PyraCloud; the handler compiles unchanged; **all handler tests pass** (they target the new SDK's public API). 
+- If the source generator (bundled in the `Mpt.Extensions.Sdk` package) does not run when consumed as a package (e.g. handler not discovered), confirm the analyzer is present under `analyzers/dotnet/cs` in the nupkg and that the package reference brings it in; the reflection fallback should still let tests pass (they construct handlers directly). The handler *discovery* is verified at runtime in Task 3's smoke.
+- If any compile error surfaces from an SDK API mismatch, fix the POC call site minimally to the new SDK API and note it. (None expected — the test file already matches.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd 'C:/repos/product-hub-extension'
+git add -A
+git commit -m "feat: migrate to pure-.NET SDK packages (drop Marketplace pkg, add Ziti)"
+```
+
+## Task 2: Native host wiring + remove the Python bridge
+
+- [ ] **Step 1: Add the Ziti platform opt-in to Program.cs**
+
+Edit `$POC/Program.cs` to serve over Ziti in platform mode and plain Kestrel locally, keeping all ProductHub DI. Add `using Mpt.Extensions.Sdk.Ziti;` and the mode switch BEFORE `ExtensionHostBuilder.Build`:
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Mpt.Extensions.Sdk.Hosting;
+using Mpt.Extensions.Sdk.Ziti;
+using ProductHubExtension.ProductHub;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// ProductHub integration (unchanged).
+builder.Services.Configure<ProductHubOptions>(
+    builder.Configuration.GetSection(ProductHubOptions.Section));
+builder.Services.AddHttpClient();
+builder.Services.AddSingleton<ProductHubTokenProvider>();
+builder.Services.AddHttpClient<IProductHubClient, ProductHubClient>();
+
+// Platform mode serves over the OpenZiti overlay using the persisted identity (registration
+// runs first). Anything else runs locally on plain Kestrel and skips registration.
+if (string.Equals(builder.Configuration["SDK_MODE"], "platform", StringComparison.OrdinalIgnoreCase))
+    builder.UseZiti();
+else
+    builder.Configuration["SDK_MODE"] = "local";
+
+var app = ExtensionHostBuilder.Build(builder);
+app.Run();
+```
+(Preserve the exact ProductHub registrations already present in the file — read it first and keep them verbatim; only add the `using` + the mode switch.)
+
+- [ ] **Step 2: Replace the bridge Dockerfile with a pure-.NET image**
+
+Overwrite `$POC/Dockerfile` (no Python bridge; ASP.NET Core runtime base; the `OpenZiti.NET.native` linux-x64 asset ships with the published app):
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish ProductHubExtension.csproj -c Release -o /app
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
+WORKDIR /app
+COPY --from=build /app .
+# Platform mode: set SDK_MODE=platform, SDK_EXTENSION_ID, SDK_EXTENSION_API_KEY,
+# SDK_EXTENSION_URL, MPT_API_BASE_URL, SDK_IDENTITY_FILE_PATH (see the SDK docs).
+ENTRYPOINT ["dotnet", "ProductHubExtension.dll"]
+```
+(If publishing the Ziti native asset for linux-x64 needs a RID, the runtime base + framework-dependent publish should still carry `OpenZiti.NET.native`'s `runtimes/linux-x64/native` payload; if a smoke later shows the native lib missing, add `-r linux-x64 --self-contained false` to the publish. Leave as-is for now.)
+
+- [ ] **Step 3: Remove the bridge compose files**
+
+```bash
+cd 'C:/repos/product-hub-extension'
+git rm docker-compose.yaml docker-compose.platform.yaml
+```
+(They orchestrated the Python bridge sidecar, which no longer exists. If the team wants a local compose, it can be a single-service file later — out of scope here.)
+
+- [ ] **Step 4: Build the publishable app to confirm the container build will succeed**
+
+```bash
+cd 'C:/repos/product-hub-extension'
+dotnet publish ProductHubExtension.csproj -c Release -o ./bin/publish-check
+```
+Expected: publish succeeds; `./bin/publish-check` contains `ProductHubExtension.dll` and (under `runtimes/`) the OpenZiti native assets. Then delete the check dir (`rm -rf ./bin/publish-check`) — it's a verification only.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd 'C:/repos/product-hub-extension'
+git add -A
+git commit -m "feat: pure-.NET host (UseZiti platform opt-in) + drop Python bridge Docker/compose"
+```
+
+## Task 3: Local smoke (handler discovery end-to-end)
+
+- [ ] **Step 1: Run the migrated extension locally and confirm discovery + endpoints**
+
+```bash
+cd 'C:/repos/product-hub-extension'
+dotnet run --project ProductHubExtension.csproj --urls http://127.0.0.1:8902 > /tmp/poc.log 2>&1 &
+APP_PID=$!
+for i in $(seq 1 25); do sleep 1; if curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8902/__health | grep -q 200; then break; fi; done
+echo "=== HEALTH ==="; curl -s http://127.0.0.1:8902/__health; echo
+echo "=== MANIFEST ==="; curl -s http://127.0.0.1:8902/__manifest; echo
+kill $APP_PID 2>/dev/null
+```
+Expected: `/__health` → `{"status":"ok"}`; `/__manifest` lists the event `platform.catalog.productItem.created` at its path with `condition` `eq(product.id,PRD-7811-7846)` — proving the **bundled source generator discovered the POC's handler from the packaged SDK**. (Default mode is local; no Ziti bind, no registration network call.) Ensure no leftover process holds the port (kill the child; on Windows `taskkill` the `ProductHubExtension` process if needed). If the manifest shows the event, the acceptance check passes.
+
+- [ ] **Step 2: Record the outcome**
+
+If `/__manifest` did NOT list the handler (source generator didn't run from the package), note it as a finding: the reflection fallback would still serve it at runtime, but investigate whether the analyzer is correctly bundled/consumed from the nupkg. Do not silently pass.
+
+- [ ] **Step 3: Final commit (if anything changed during smoke, e.g. a `.gitignore` for bin/)**
+
+Add a `$POC/.gitignore` if absent (ignore `bin/`, `obj/`, `.packages/`, `identity/`), then:
+```bash
+cd 'C:/repos/product-hub-extension'
+git add -A
+git commit -m "chore: gitignore + local smoke verified"
+```
+
+---
+
+## Self-review notes
+
+- **Acceptance check = Task 1 Step 5** (POC tests pass against the new SDK) **+ Task 3** (handler discovered + served by the packaged SDK at runtime). Together they prove the pure-.NET SDK is a drop-in for a real extension.
+- **No handler/test code changes expected** — the new SDK preserved the authoring API (verified against the POC's test file). Any required change is a finding to report, not a silent edit.
+- **Bridge fully removed:** Dockerfile rewritten, both compose files deleted, `Mpt.Extensions.Sdk.Marketplace` dropped. The POC keeps its own `ProductItem` model (model-agnostic SDK).
+- **Feeds:** the POC's nuget.config gains nuget.org + PyraCloud (needed for `OpenZiti.NET`); this environment reaches both.
+- **Safety:** the POC wasn't under version control; Task 1 Step 1 initialises git + a baseline commit so the in-place migration is reversible.
+- **Live Ziti** is still only validatable in a real platform environment (the deployment smoke from Plan 2) — out of scope for this local acceptance check.

--- a/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md
+++ b/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md
@@ -254,15 +254,24 @@ ctx.Marketplace.GetAsync<TOrder>("/commerce/orders/ORD-...")   // TOrder is the 
 
 ## Risks & open questions
 
-1. **Ziti-bound Kestrel transport (highest delivery risk).** Confirm `OpenZiti.NET` exposes a
-   `Stream`/socket-level server binding consumable by Kestrel's `IConnectionListenerFactory`
-   (vs. only a higher-level HTTP helper). **Mitigation:** throwaway spike as the first task;
-   B2 sidecar fallback; the `Ziti` package boundary makes the choice swappable.
+1. **Ziti-bound Kestrel transport — RESOLVED (spike, 2026-06-19).** `OpenZiti.NET`
+   `1.0.26159.2780` targets **net8.0** with **linux-x64/win-x64** natives, and the repo ships a
+   reference **`ZitiConnectionListenerFactory : IConnectionListenerFactory`** + a
+   `UseZitiTransport(identity, service)` host extension. An accepted `ZitiSocket` converts to a
+   real `System.Net.Sockets.Socket`, fed to Kestrel's own `SocketConnectionContextFactory` — no
+   hand-rolled `IDuplexPipe`. **Decision: B1 (app-embedded), adapting the upstream sample.** B2
+   (sidecar) dropped. The accept API is synchronous, bridged to Kestrel via a background
+   accept-loop + `Channel` (as in the sample).
 2. **Native dependency / packaging.** `OpenZiti.NET` carries a native `ziti-sdk-c` component;
    confirm Linux-container + Windows-dev RID handling, and net8.0 compatibility of the package.
    Isolated in one package.
-3. **Identity format mapping.** Confirm the platform's `channel.identity` (`mrok`-keyed) maps
-   cleanly to what `OpenZiti.NET` loads (already-enrolled identity vs enrollment JWT).
+3. **Identity format mapping — RESOLVED (inspected a real POC identity, 2026-06-19).** The
+   persisted `channel.identity` IS a standard **enrolled** OpenZiti identity JSON
+   (`ztAPI`, `id.{key,cert,ca}` PEM, `enableHa`) plus an extra non-ziti **`mrok`** metadata key
+   (`extension`/`instance`/`domain`/`tags`). So: no enrollment-JWT flow; just write the JSON to a
+   file (optionally strip `mrok`) and load by path. **Open:** confirm the **bind service name**
+   with the platform team — the identity carries `mrok.tags.mrok-service` = the extension id
+   (e.g. `ext-5034-5001`), which is the likely service to bind.
 4. **net10 → net8 retarget.** The existing SDK/POC are net10.0; retargeting may surface
    net10-only API usage to fix. Expected small.
 5. **Auth verification boundary.** The bridge/gateway verified the JWT; confirm the same trust

--- a/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md
+++ b/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md
@@ -44,11 +44,13 @@ no Python in the container.
 
 ## Decisions (made now; flag if any should change)
 
-1. **Home: new separate repository** (working name `mpt-extension-sdk-dotnet`), per the
-   earlier decision. The reusable parts of `C:\repos\mpt-extension-dotnet-sdk\src\Mpt.Extensions.Sdk`
-   (attributes, contexts, dispatch, discovery, manifest, source-gen) are **lifted into the new
-   repo**; the Python `bridge/` is dropped. *(If you'd rather evolve the existing repo in place
-   and delete `bridge/`, say so — it's less lift-and-shift but mixes old/new history.)*
+1. **Home: `C:\repos\mpt-extension-sdk-dotnet`** — evolve this directory in place. It already
+   contains the bridge-based SDK (`src/Mpt.Extensions.Sdk`, `bridge/`, `codegen`, `tests`,
+   `tools`). The work: **keep the C# authoring SDK, drop the Python `bridge/`**, and add native
+   registration/Ziti/egress. The separate GitHub-linked repo `C:\repos\mpt-extension-dotnet-sdk`
+   is left untouched for now.
+   - **Open item:** this directory has **no git remote**. A remote must be wired up before
+     publishing/CI (decide whether to push here or reconcile with the GitHub repo later).
 2. **Target framework: net10.0**, matching the existing `Mpt.Extensions.Sdk` and the
    `product-hub-extension` POC. *(This supersedes the earlier net8.0 choice, which was made
    before we knew the existing SDK and POC are net10.0. The platform models are net8.0 and
@@ -266,8 +268,10 @@ ctx.Marketplace.GetAsync<OrderEntity>("/commerce/orders/ORD-...")
 ## Build sequence (high level — detailed plan follows)
 
 1. Ziti + Kestrel transport spike (resolve Risk 2) — throwaway.
-2. New repo + solution scaffold, net10.0, PyraCloud feed (`nuget.config`), CI, NuGet metadata.
-3. Lift `Mpt.Extensions.Sdk` authoring code into `Swo.Mpt.Extensions.Abstractions`; keep its tests green.
+2. In `C:\repos\mpt-extension-sdk-dotnet`: ensure net10.0 + PyraCloud feed (`nuget.config`),
+   then remove the Python `bridge/` and its build wiring; keep the C# solution building.
+3. Restructure the existing `Mpt.Extensions.Sdk` into the package split (Abstractions / Hosting /
+   Ziti); keep its existing tests green throughout.
 4. `Swo.Mpt.Extensions.Hosting`: native JWT auth → account-token provider + `IMptApiClient`
    (with platform-model serialization parity, Risk 1) → reimplement `IMarketplaceClient` on it
    → registration hosted service → `meta.yaml` generation. Plain Kestrel; tests.

--- a/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md
+++ b/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md
@@ -1,240 +1,277 @@
-# .NET Extension SDK — Design
+# Pure-.NET Extension SDK — Design
 
 **Date:** 2026-06-19
-**Status:** Approved for planning
+**Status:** Draft for review (revised after discovering the existing bridge-based SDK and platform NuGet models)
 **Authors:** MPT team (via Claude Code)
 
 ## Summary
 
-The team is shifting SoftwareONE Marketplace extension development from the Python
-`mpt-extension-sdk` to a pure .NET implementation. This document designs a small set of
-reusable .NET libraries that a C# extension service can reference to get the same
-capabilities the Python SDK provides today: a typed Marketplace API client, an extension
-hosting/runtime model (instance registration, event/API routing, typed contexts,
-pipelines), and OpenZiti-based platform transport.
+The team is moving SoftwareONE Marketplace extension development to a **pure .NET**
+implementation. A bridge-based .NET SDK already exists at `C:\repos\mpt-extension-dotnet-sdk`
+(`Mpt.Extensions.Sdk`): it gives extension authors an attribute-driven model
+(`[EventHandler]`, `[ApiEndpoint]`, `[Plug]`, `[ScheduleHandler]`), typed contexts, a
+manifest source generator, and an `ExtensionHostBuilder` — but it delegates registration,
+OpenZiti transport, `meta.yaml`, and Marketplace API calls to a **Python bridge sidecar**.
 
-The .NET libraries live in a **new, separate repository** (working name
-`mpt-extension-sdk-dotnet`). They target **net8.0 (LTS)** and ship as NuGet packages.
+This design **removes the Python bridge** and reimplements its three responsibilities
+natively in .NET, while keeping the existing C# authoring surface. It also adopts the
+**platform domain models published on the PyraCloud NuGet feed**
+(`Mpt.Models.Platform`, `Mpt.Models.Core`) instead of bespoke/generated models.
+
+The result is a small set of libraries a C# service references to build an extension with
+no Python in the container.
 
 ## Goals
 
-- Provide a typed, ergonomic Marketplace API client for C# services (orders, agreements,
-  subscriptions, assets, products, installations, tasks, templates).
-- Reproduce the two-token auth model: a long-lived extension key for bootstrap, and
-  per-account JWT tokens that are minted, cached, and auto-refreshed.
-- Reproduce instance registration and identity persistence.
-- Provide an ASP.NET Core hosting model so a service can declare event/task handlers and
-  API endpoints, receive typed contexts, and process them through pipelines.
-- Connect to the platform over OpenZiti, matching today's `ziticorn` transport, while
-  keeping local development on plain Kestrel.
+- Keep the existing, good authoring model from `Mpt.Extensions.Sdk` (attributes, contexts,
+  `EventResponse`, source-gen, `ExtensionHostBuilder`).
+- Replace the Python bridge with native .NET:
+  - **Registration + identity persistence** on startup.
+  - **OpenZiti transport** so the host receives platform traffic over the overlay
+    (`OpenZiti.NET`), replacing `mrok`/`ziticorn`.
+  - **Direct, account-scoped Marketplace API access** (mint/cache/refresh account tokens,
+    call the MPT API over Ziti), replacing the bridge `/__egress` proxy.
+  - **Native `meta.yaml` generation** from the manifest, replacing the bridge's `meta.py`.
+- Reuse platform NuGet domain models (`Mpt.Models.Platform` / `Mpt.Models.Core`).
+- Preserve local development without Ziti (plain Kestrel), mirroring today's local mode.
 
 ## Non-Goals
 
-- Porting the Python `Plug` and `Schedule` route families. (`Plug` is declarative
-  metadata + static assets; `Schedule` is modeled but not mounted in the Python runtime.)
-  These can be added later; they are out of scope for the first deliverable.
-- Porting the Typer-based `mpt-ext` CLI. Metadata generation is provided as a library
-  capability and (optionally) a `dotnet` tool later.
-- A drop-in line-by-line port. We map Python concepts onto idiomatic .NET
-  (minimal-API/builder style, `HttpClient`, `IHostedService`, DI) rather than mirroring
-  Python class structure.
+- Rewriting the authoring model. The attribute/context/source-gen surface stays.
+- Implementing `schedule` traffic end-to-end (routes exist but the platform doesn't drive
+  them yet) or expanding `plug` beyond today's static-asset behaviour.
+- A managed-code OpenZiti reimplementation. We wrap `OpenZiti.NET` (which wraps `ziti-sdk-c`).
 
-## Reference: what the Python SDK does today
+## Decisions (made now; flag if any should change)
 
-The behaviours we are reproducing (verified against `mpt_extension_sdk/`):
+1. **Home: new separate repository** (working name `mpt-extension-sdk-dotnet`), per the
+   earlier decision. The reusable parts of `C:\repos\mpt-extension-dotnet-sdk\src\Mpt.Extensions.Sdk`
+   (attributes, contexts, dispatch, discovery, manifest, source-gen) are **lifted into the new
+   repo**; the Python `bridge/` is dropped. *(If you'd rather evolve the existing repo in place
+   and delete `bridge/`, say so — it's less lift-and-shift but mixes old/new history.)*
+2. **Target framework: net10.0**, matching the existing `Mpt.Extensions.Sdk` and the
+   `product-hub-extension` POC. *(This supersedes the earlier net8.0 choice, which was made
+   before we knew the existing SDK and POC are net10.0. The platform models are net8.0 and
+   are consumable from net10.0.)*
+3. **Domain models: reuse `Mpt.Models.Platform` + `Mpt.Models.Core`** from the PyraCloud
+   feed, per direction. See Risk 1 for the serialization-parity work this implies.
 
-- **Registration** (`runtime/bootstrap/registration.py`): builds
-  `{externalId, version, meta}`, adds `channel: {}` when no matching identity exists, then
-  `POST /public/v1/integration/extensions/{extensionId}/instances` with a bearer extension
-  key. The response's `channel.identity` (OpenZiti credentials, keyed under `mrok`) is
-  persisted to an identity file.
-- **Transport** (`runtime/runner.py`): local mode runs `uvicorn`; platform mode calls
-  `register_instance()` then serves the ASGI app through `ziticorn.run(app, identityFile, …)`.
-- **API client** (`services/mpt_api_service/`): `MPTAPIService` wraps an async client and
-  exposes sub-services. Account scoping is done by an account-token provider that injects a
-  fresh per-account JWT on every request (60s refresh leeway, per-account lock).
-- **Routing** (`routing/`): `EventRouter` (event vs task delivery), `ApiRouter` (REST).
-- **Pipeline** (`pipeline/`): `BasePipeline`/`BaseStep` with `pre/process/post` lifecycle
-  and `Defer`/`Skip`/`Stop`/`Fail` control-flow signals; typed `OrderContext` /
-  `AgreementContext` built by a context factory from the inbound event.
-- **Auth** (`api/auth/`, `jwt.py`): extracts `Authorization: Bearer`, decodes (does not
-  verify — the gateway verifies) SoftwareONE claims
-  (`https://claims.softwareone.com/{accountId,accountType,extensionId,modules}`), checks
-  `exp` with a leeway.
+## Existing assets we keep (from `Mpt.Extensions.Sdk`)
+
+Verified by reading the source:
+
+- **Attributes** (`Attributes/`): `EventHandlerAttribute` (`Event`, `Condition`, task flag),
+  `ApiEndpointAttribute`, `PlugAttribute`, `ScheduleHandlerAttribute`.
+- **Contexts** (`Contexts/`): `IExtensionContext`, `EventContext` (carries `Event`,
+  `AuthContext`, `IMarketplaceClient`, `ILogger`, `CancellationToken`), `ApiContext`,
+  `OrderContext`, `ScheduleContext`, `HandlerServices`.
+- **Events** (`Events/`): `Event`, `EventResponse` (`Ok` / `Delay(seconds)` / `Cancel(msg)`).
+- **Discovery + source-gen** (`Discovery/`, `Generated/`, the `SourceGen` project):
+  `GeneratedHandlerRegistry` (reflection-free) with a reflection fallback.
+- **Manifest** (`Manifest/`): `ExtensionManifest`, `RouteDescriptor`, `RouteValidation`,
+  `ManifestJson` — the `/__manifest` contract and route-collision checks.
+- **Dispatch** (`Dispatch/`): `EventDispatcher`, `ApiDispatcher`, `ScheduleDispatcher`,
+  `HandlerInvoker`.
+- **Host endpoints** (`Hosting/ExtensionEndpoints.cs`): `/__health`, `/__manifest`, one route
+  per event/API/schedule with a shared per-request pipeline.
+
+## What the bridge did that we must absorb (verified)
+
+The bridge sits between the platform and the C# host. Removing it means the SDK must take on:
+
+1. **Registration** — `POST {SDK_EXTENSION_URL}/public/v1/integration/extensions/{extensionId}/instances`
+   with `Authorization: Bearer {extensionApiKey}` and body
+   `{externalId, version, meta, [channel:{}]}`; persist the returned `channel.identity`
+   (keyed under `mrok`) to `SDK_IDENTITY_FILE_PATH`; include `channel:{}` only when there is
+   no persisted identity matching the extension id. *(Confirmed against the POC bridge,
+   tested on s1.show 2026-06-18.)*
+2. **OpenZiti transport** — after registration, serve the host over the Ziti overlay using
+   the persisted identity (today: `mrok.agent.ziticorn`).
+3. **Ingress auth** — today the bridge parses auth and forwards it as an `X-Mpt-Auth` JSON
+   header plus `X-Mpt-Egress-Session`, `x-request-id`, `mpt-task-id`. Natively, the host
+   receives the platform's real request: it must **parse `Authorization: Bearer` and decode
+   the SoftwareONE JWT claims itself** (replacing `ParseAuth`'s `X-Mpt-Auth` read), and drop
+   the bridge-token gate.
+4. **Egress** — today `IMarketplaceClient` POSTs `{Method, Path, Body, EgressSessionId}` to
+   the bridge `/__egress`, which resolves the account-scoped token and calls the MPT API.
+   Natively, a new `IMarketplaceClient` implementation must **call the MPT API directly over
+   Ziti and mint/cache/refresh the per-account token itself**.
+
+## meta.yaml (ground truth from the POC)
+
+The registration `meta` block (the basis for `meta.yaml`):
+
+```json
+{
+  "contractVersion": "1",
+  "events": [
+    {
+      "event": "platform.catalog.productItem.created",
+      "path": "/events/platform-catalog-productitem-created",
+      "condition": "eq(product.id,PRD-7811-7846)",
+      "task": false
+    }
+  ],
+  "apiEndpoints": [],
+  "schedules": [],
+  "plugs": []
+}
+```
+
+It is **generated**, not authored: today the bridge calls the host's `GET /__manifest` and
+converts it. Natively, the SDK generates `meta.yaml` directly from `ExtensionManifest` before
+registration — no host round-trip needed.
 
 ## Package architecture
 
-Three NuGet packages, split so the heavy/native Ziti dependency is isolated:
+Three packages, isolating the native Ziti dependency:
 
 ```
-Swo.Mpt.ApiClient          (HttpClient only)
+Swo.Mpt.Extensions.Abstractions   (the authoring surface; lifted from Mpt.Extensions.Sdk)
         ▲
         │
-Swo.Mpt.Extensions.Hosting (ASP.NET Core; depends on ApiClient)
-        ▲
+Swo.Mpt.Extensions.Hosting        (ASP.NET Core host: endpoints, real-JWT auth, registration,
+        ▲                          direct MptApiClient, meta.yaml gen)
         │
-Swo.Mpt.Extensions.Ziti    (depends on Hosting + OpenZiti.NET)
+Swo.Mpt.Extensions.Ziti           (OpenZiti transport; depends on Hosting + OpenZiti.NET)
 ```
 
-A consuming service references:
+> Naming TBD — could keep the `Mpt.Extensions.Sdk*` family from the existing repo. The split
+> matters more than the names.
 
-- `ApiClient` alone for pure outbound API access, **or**
-- `Hosting` to author an extension that runs on plain Kestrel (local dev), **or**
-- `Hosting` + `Ziti` for platform deployment over the Ziti overlay.
+### `Swo.Mpt.Extensions.Abstractions`
 
-### `Swo.Mpt.ApiClient`
+The current `Mpt.Extensions.Sdk` authoring code, lifted with minimal change: attributes,
+`IExtensionContext`/`EventContext`/`ApiContext`/`OrderContext`/`ScheduleContext`, `Event`,
+`EventResponse`, `IMarketplaceClient`, manifest types, dispatch, discovery, source-gen.
+`AuthContext` is enriched to carry the decoded SoftwareONE claims (accountId, accountType,
+extensionId, modules) since the host now decodes the JWT itself.
 
-Mirrors `services/mpt_api_service`, `api/auth`, and `models`.
+### `Swo.Mpt.Extensions.Hosting` (the bulk of the new work)
 
-- **Domain models**: records for Agreement, Order, Subscription, Asset, Product,
-  ProductItem, Installation, Task, Template, plus shared types (Account, Address, Contact,
-  Parameter, Price, Licensee, Authorization, ExternalId, Audit). System.Text.Json with
-  source-generated contexts.
-- **`IMptApiClient`** exposing sub-clients:
-  `Agreements`, `Orders`, `Subscriptions`, `Assets`, `Products`, `ProductItems`,
-  `Installations`, `Tasks`, `Templates`, `AccountTokens`.
-  Operations follow the Python services, e.g. `Orders.GetByIdAsync`, `Orders.CompleteAsync`,
-  `Orders.QueryAsync`, `Orders.FailAsync`, `Orders.UpdateAsync`;
-  `Agreements.GetAllAsync` (paginated), `GetByIdAsync`, `UpdateAsync`;
-  `Assets.CreateAsync` / `CreateOrderAssetAsync`; `Subscriptions.Create*`; etc.
-- **Pagination**: `PaginatedCollection<T> { Limit, Offset, Total, IReadOnlyList<T> Resources }`
-  with an `IAsyncEnumerable<T>` convenience wrapper for auto-paging.
-- **Auth**:
-  - `SoftwareOneJwt.ParseClaims(token)` — decode (not verify) claims; typed accessors for
-    accountId, accountType (`Client`/`Operations`/`Vendor`), extensionId, modules; expiry
-    check with leeway.
-  - `IAccountTokenProvider` — given an account id, returns a valid token, minting via
-    `POST /public/v1/integration/installations/token?account.id={id}` using the extension
-    key, caching per account, refreshing within a leeway window, serialized per-account.
-  - Two factory paths matching Python `from_config` (extension key) and
-    `from_auth_context` (account-scoped). Account scoping is implemented as a
-    `DelegatingHandler` that injects the fresh per-account token.
-- Configured through `IHttpClientFactory` + typed `MptApiOptions` (base URL, extension key,
-  timeouts). No ASP.NET Core dependency.
+ASP.NET Core integration; depends on `Abstractions` + the platform model packages.
 
-### `Swo.Mpt.Extensions.Hosting`
-
-Mirrors `runtime`, `routing`, `pipeline`, `extension_app`. ASP.NET Core integration.
-
-- **Authoring API** (builder style over ASP.NET Core):
-  ```csharp
-  var builder = ExtensionApp.CreateBuilder(args);
-  builder.Events.OnTask("order.created", async (OrderContext ctx) => { ... });
-  builder.Events.OnEvent("agreement.updated", async (AgreementContext ctx) => { ... });
-  builder.Api.MapGet("/things/{id}", (ApiContext ctx, string id) => Results.Ok());
-  var app = builder.Build();
-  await app.RunAsync();
-  ```
-- **Contexts**: `ExtensionContext` (base: logger, `IMptApiClient`, settings, auth),
-  `EventContext` (+ event metadata, mutable state bag), `OrderContext` (+ `Order`,
-  `RefreshOrderAsync`), `AgreementContext` (+ `Agreement`, `RefreshAgreementAsync`),
-  `ApiContext` (+ request, auth). A context factory inspects the inbound event's object
-  type, fetches the Order/Agreement via the account-scoped client, and builds the right
-  typed context.
-- **Pipeline engine**: `IPipelineStep` with `PreAsync`/`ProcessAsync`/`PostAsync`
-  (`post` always runs); `Pipeline` runs steps sequentially; control-flow via exceptions
-  `DeferStepException`, `SkipStepException`, `StopStepException`, `FailException`. The event
-  handler maps these onto task lifecycle calls.
-- **Registration + lifecycle**: an `IHostedService` runs registration on startup
-  (build payload → POST instances → persist identity), then hands off to the configured
-  transport. Plain-Kestrel transport is the default in this package.
-- **Metadata**: generate `meta.yaml` (events and their metadata) before startup, matching
-  the Python `meta_config` contract.
-- **Request handling**: minimal-API endpoints that authenticate the JWT, build the
-  account-scoped client + typed context, invoke the handler/pipeline, and translate results
-  into task lifecycle calls (`Tasks.Start/Complete/Fail/Reschedule`). Correlation-id and
-  task-id headers flow through `Activity`/logging scope.
+- **`ExtensionHostBuilder.Build(builder)`** — unchanged authoring entrypoint; rewires the
+  per-request pipeline to native auth + native Marketplace client and registers the hosted
+  services below.
+- **Ingress auth**: a `SoftwareOneJwt` claims parser + request authenticator replaces the
+  `X-Mpt-Auth` path — extract `Authorization: Bearer`, decode (not verify; the gateway
+  verifies) claims `https://claims.softwareone.com/{accountId,accountType,extensionId,modules}`,
+  check `exp` with leeway, build `AuthContext`. Bridge-token gate removed.
+- **`IMptApiClient` + account tokens**: a direct MPT API client (typed `HttpClient` via
+  `IHttpClientFactory`) that injects a fresh **account-scoped token** per request. An
+  `IAccountTokenProvider` mints tokens via
+  `POST /public/v1/integration/installations/token?account.id={id}` using the extension key,
+  caches per account, and refreshes within a leeway window (serialized per account). This is
+  the native replacement for the bridge's egress + token resolver. The existing
+  `IMarketplaceClient` (generic `GetAsync<T>/PostAsync<T>/PutAsync<T>`) is reimplemented on
+  top of it, so handler code is unchanged.
+- **Registration hosted service**: on startup (platform mode) build the payload, POST
+  instances, persist identity, then signal the transport. Fail fast on non-2xx; never start
+  the Ziti transport without an identity.
+- **`meta.yaml` generation**: serialize `ExtensionManifest` to the `meta` schema above before
+  registration.
+- **Config**: typed options bound from the same env vars the bridge used —
+  `SDK_EXTENSION_ID`, `SDK_EXTENSION_API_KEY`, `SDK_EXTENSION_URL`, `MPT_API_BASE_URL`,
+  `SDK_EXTENSION_EXTERNAL_ID`, `SDK_IDENTITY_FILE_PATH`, plus a local/platform mode switch.
 
 ### `Swo.Mpt.Extensions.Ziti`
 
-Mirrors `mrok`/`ziticorn`. Isolated native dependency (`OpenZiti.NET`).
+Isolated `OpenZiti.NET` dependency.
 
-- Maps the persisted platform identity (`channel.identity`, the `mrok`-keyed JSON) to an
-  OpenZiti identity the SDK can load.
-- Provides the Ziti-bound server transport that replaces Kestrel's default TCP listener,
-  registered via `builder.UseZitiTransport()`.
-- **Target transport (B1):** a custom Kestrel `IConnectionListenerFactory` backed by an
-  `OpenZiti.NET` service binding, so inbound platform connections arrive over the overlay
-  in-process (app-embedded zero trust, single process — matches `ziticorn`).
-- **Documented fallback (B2):** a `ziti-edge-tunnel` sidecar exposes the service on
-  localhost and Kestrel binds localhost. Used only for bring-up if B1 is blocked.
+- Maps the persisted `channel.identity` (the `mrok`-keyed JSON) to an OpenZiti identity.
+- **Target (B1):** a custom Kestrel `IConnectionListenerFactory` backed by an `OpenZiti.NET`
+  service binding, so inbound platform connections arrive over the overlay in-process —
+  app-embedded zero trust, single process, matching `ziticorn`. Enabled via
+  `builder.UseZitiTransport()`.
+- **Fallback (B2):** a `ziti-edge-tunnel` sidecar exposing the service on localhost, Kestrel
+  binds localhost. Bring-up only.
+- Outbound (`IMptApiClient`) also dials the MPT API over the same Ziti context.
 
 ## Data flow
 
 **Startup (platform):**
 ```
 Host start
-  → RegistrationHostedService
-      build {externalId, version, meta} (+ channel:{} if no matching identity)
-      POST /public/v1/integration/extensions/{extensionId}/instances  (Bearer extension key)
-      persist channel.identity → identity file
+  → generate meta.yaml from ExtensionManifest
+  → RegistrationHostedService: POST instances (Bearer extension key) → persist channel.identity
   → Ziti transport binds Kestrel to the Ziti service using that identity
   → ready
 ```
 
-**Inbound event/task:**
+**Inbound event/task (no bridge):**
 ```
-Ziti overlay → Kestrel (Ziti transport) → minimal-API endpoint
-  authenticate JWT (parse claims, check exp)
-  resolve account-scoped IMptApiClient (account token via IAccountTokenProvider)
-  context factory: fetch Order/Agreement → build OrderContext/AgreementContext
-  Tasks.StartAsync(taskId)            (task delivery only)
-  run handler / pipeline
-    Defer  → Tasks.RescheduleAsync
-    Stop   → cancel
-    Fail   → Tasks.FailAsync
-    ok     → Tasks.CompleteAsync
-  return response
+Ziti overlay → Kestrel (Ziti transport) → mapped route (e.g. /events/...)
+  parse Authorization: Bearer → decode SWO claims → AuthContext
+  build HandlerServices { DI scope, IMarketplaceClient(account-scoped), logger }
+  dispatch to [EventHandler] → returns EventResponse (Ok/Delay/Cancel)
+  → JSON response to platform
+```
+
+**Egress (handler → Marketplace, no bridge):**
+```
+ctx.Marketplace.GetAsync<OrderEntity>("/commerce/orders/ORD-...")
+  → IMptApiClient: ensure fresh account token (IAccountTokenProvider) → HTTP over Ziti
+  → MPT API → deserialize into platform model
 ```
 
 ## Error handling
 
-- API client: typed `MptApiException` carrying status code + Marketplace error body;
-  transient-retry policy (e.g. via `Microsoft.Extensions.Http.Resilience`) on idempotent
-  reads and token minting.
-- Hosting: handler exceptions map to HTTP responses for API routes and to task lifecycle
-  outcomes for events; pipeline control-flow exceptions are first-class (not errors).
-- Registration: fail fast with a clear message on non-2xx; never start the transport
-  without an identity in platform mode.
+- Marketplace client: typed exception with status + body; transient retry on idempotent
+  reads and token minting (`Microsoft.Extensions.Http.Resilience`).
+- Event handlers: existing `EventResponse` model (`Delay` → platform retry, `Cancel` → stop);
+  unhandled exceptions return a structured 500 (platform retries), preserving today's
+  semantics now that the host owns the response.
+- Registration: fail fast and do not start the transport without an identity.
 
 ## Testing strategy
 
-- `ApiClient`: unit tests against a mocked `HttpMessageHandler` (request shape, auth header
-  injection, pagination, token caching/refresh/leeway, error mapping). No network.
-- `Hosting`: `WebApplicationFactory`-based tests on plain Kestrel — auth, context building,
-  handler dispatch, pipeline control-flow → task lifecycle mapping, registration payload.
-- `Ziti`: validated first by a **throwaway spike** (see Risks), then a thin integration
-  smoke test; the transport seam lets all `Hosting` tests run without Ziti.
+- Authoring/dispatch: keep the existing unit tests from `Mpt.Extensions.Sdk` (host endpoints,
+  dispatch, discovery, manifest, route validation) on plain Kestrel via `WebApplicationFactory`.
+- Auth: JWT claims parsing, expiry leeway, account scoping.
+- Marketplace client: mocked `HttpMessageHandler` — request shape, token injection,
+  caching/refresh, error mapping, and **platform-model (de)serialization parity** (see Risk 1).
+- Registration: payload shape + identity persistence/reuse, asserted against the captured POC
+  payload.
+- Ziti: validated by a **throwaway spike first** (Risk 2), then a thin integration smoke test.
 
 ## Risks & open questions
 
-1. **Ziti-bound Kestrel transport (highest risk).** Must confirm `OpenZiti.NET` exposes a
-   `Stream`/socket-level server binding consumable by Kestrel's
-   `IConnectionListenerFactory`, rather than only a higher-level HTTP helper. **Mitigation:**
-   the first task in the implementation plan is a throwaway spike that stands up a Ziti
-   service binding feeding Kestrel and serves one request end-to-end. The rest of the design
-   assumes B1 but is gated on the spike; B2 (sidecar) is the fallback. The `Ziti` package
-   boundary makes the choice swappable without touching `Hosting`.
-2. **Native dependency / packaging.** `OpenZiti.NET` carries a native `ziti-sdk-c`
-   component (`OpenZiti.NET.native`); confirm Linux container + Windows dev support and RID
-   handling. Isolating it in one package limits blast radius.
-3. **Identity format mapping.** The platform returns identity under a `mrok` key; confirm
-   the exact JSON maps cleanly to what `OpenZiti.NET` loads (enrollment vs already-enrolled
-   identity).
-4. **`meta.yaml` schema fidelity.** Reproduce the Python `meta_config` output exactly so
-   the platform accepts the registration payload; pin against a captured sample.
-5. **JWT verification boundary.** Python decodes-without-verifying because the gateway
-   verifies. Confirm the same trust boundary holds for the .NET service behind Ziti.
+1. **Platform models vs public-API JSON (decided to reuse models; this is the cost).**
+   `Mpt.Models.Platform` types are server-side RQL entities: PascalCase, `null!` non-nullable
+   defaults, and `Status`-style fields are `Enumeration` objects (`{Name, Id, AlternateNames}`),
+   not JSON strings. The public API JSON is camelCase, string-valued, and RQL-projected
+   (partial). The platform serializes responses through an RQL serializer + custom converters
+   (`Presentation.WebApi/Startup.cs`). So deserializing API responses into these models needs
+   client-side parity: a camelCase policy, an `Enumeration`-from-string `JsonConverterFactory`,
+   optional/omitted-field tolerance, and care with `null!` properties when RQL omits fields.
+   **Mitigation:** an early task builds and unit-tests an `MptJson` options set against captured
+   real responses for the core resources (Order, Agreement, Subscription, Asset, ProductItem);
+   if parity proves expensive for a given resource, fall back to a thin API-shaped DTO for that
+   resource only. The generic `IMarketplaceClient.GetAsync<T>` means this is per-resource, not
+   all-or-nothing.
+2. **Ziti-bound Kestrel transport (highest delivery risk).** Confirm `OpenZiti.NET` exposes a
+   `Stream`/socket-level server binding consumable by Kestrel's `IConnectionListenerFactory`
+   (vs. only a higher-level HTTP helper). **Mitigation:** throwaway spike as the first task;
+   B2 sidecar fallback; the `Ziti` package boundary makes the choice swappable.
+3. **Native dependency / packaging.** `OpenZiti.NET` carries a native `ziti-sdk-c` component;
+   confirm Linux-container + Windows-dev RID handling. Isolated in one package.
+4. **Identity format mapping.** Confirm the platform's `channel.identity` (`mrok`-keyed) maps
+   cleanly to what `OpenZiti.NET` loads (already-enrolled identity vs enrollment JWT).
+5. **Repo strategy + history.** New repo (lift the reusable code) vs evolve the existing repo
+   (delete `bridge/`). Decision 1 above; confirm.
+6. **Auth verification boundary.** The bridge/gateway verified the JWT; confirm the same trust
+   boundary holds when the .NET host terminates Ziti directly (decode-not-verify stays valid).
 
 ## Build sequence (high level — detailed plan follows)
 
-1. Ziti+Kestrel transport spike (resolve Risk 1) — throwaway.
-2. New repo + solution scaffold, CI, net8.0, NuGet metadata.
-3. `Swo.Mpt.ApiClient`: models → auth/JWT → account-token provider → sub-clients →
-   pagination → error handling, with tests.
-4. `Swo.Mpt.Extensions.Hosting`: contexts → builder/authoring API → registration hosted
-   service → event/API dispatch → pipeline engine → meta generation, on plain Kestrel,
-   with tests.
+1. Ziti + Kestrel transport spike (resolve Risk 2) — throwaway.
+2. New repo + solution scaffold, net10.0, PyraCloud feed (`nuget.config`), CI, NuGet metadata.
+3. Lift `Mpt.Extensions.Sdk` authoring code into `Swo.Mpt.Extensions.Abstractions`; keep its tests green.
+4. `Swo.Mpt.Extensions.Hosting`: native JWT auth → account-token provider + `IMptApiClient`
+   (with platform-model serialization parity, Risk 1) → reimplement `IMarketplaceClient` on it
+   → registration hosted service → `meta.yaml` generation. Plain Kestrel; tests.
 5. `Swo.Mpt.Extensions.Ziti`: identity mapping → transport (B1, informed by the spike) →
    integration smoke test.
-6. Sample/reference extension service + consumer docs.
+6. Port `product-hub-extension` to the pure-.NET SDK as the reference/acceptance check (drop
+   the bridge, confirm parity against s1.show).

--- a/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md
+++ b/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md
@@ -54,7 +54,10 @@ no Python in the container.
    before we knew the existing SDK and POC are net10.0. The platform models are net8.0 and
    are consumable from net10.0.)*
 3. **Domain models: reuse `Mpt.Models.Platform` + `Mpt.Models.Core`** from the PyraCloud
-   feed, per direction. See Risk 1 for the serialization-parity work this implies.
+   feed. These are the published **Marketplace standard contracts**, so they are the correct
+   (de)serialization target for API responses — confirmed safe to use directly. The only
+   remaining mechanical step is pointing `MptJson` at the matching serializer options
+   (camelCase + any `Enumeration` converter the contract package ships); see Risk 1.
 
 ## Existing assets we keep (from `Mpt.Extensions.Sdk`)
 
@@ -237,19 +240,16 @@ ctx.Marketplace.GetAsync<OrderEntity>("/commerce/orders/ORD-...")
 
 ## Risks & open questions
 
-1. **Platform models vs public-API JSON (decided to reuse models; this is the cost).**
-   `Mpt.Models.Platform` types are server-side RQL entities: PascalCase, `null!` non-nullable
-   defaults, and `Status`-style fields are `Enumeration` objects (`{Name, Id, AlternateNames}`),
-   not JSON strings. The public API JSON is camelCase, string-valued, and RQL-projected
-   (partial). The platform serializes responses through an RQL serializer + custom converters
-   (`Presentation.WebApi/Startup.cs`). So deserializing API responses into these models needs
-   client-side parity: a camelCase policy, an `Enumeration`-from-string `JsonConverterFactory`,
-   optional/omitted-field tolerance, and care with `null!` properties when RQL omits fields.
-   **Mitigation:** an early task builds and unit-tests an `MptJson` options set against captured
-   real responses for the core resources (Order, Agreement, Subscription, Asset, ProductItem);
-   if parity proves expensive for a given resource, fall back to a thin API-shaped DTO for that
-   resource only. The generic `IMarketplaceClient.GetAsync<T>` means this is per-resource, not
-   all-or-nothing.
+1. **Serializer options for the contract models (low risk — routine confirmation).**
+   The `Mpt.Models.Platform` types are the published Marketplace standard contracts and are
+   safe to deserialize into. The only thing to nail down is the `JsonSerializerOptions` they
+   expect: the types use PascalCase properties and `Enumeration`-typed fields
+   (`{Name, Id, AlternateNames}`), so the SDK's shared `MptJson` options must match the
+   contract's wire format (camelCase policy and an `Enumeration` (de)serialization converter —
+   reuse the one the contract/`Mpt.Models.Core` package ships if available, otherwise a small
+   `JsonConverterFactory` that maps the string name ↔ `Enumeration`). **Mitigation:** an early
+   task round-trips a couple of captured real responses (Order, Agreement) through the models
+   to lock the options in; expected to be a small, one-time configuration.
 2. **Ziti-bound Kestrel transport (highest delivery risk).** Confirm `OpenZiti.NET` exposes a
    `Stream`/socket-level server binding consumable by Kestrel's `IConnectionListenerFactory`
    (vs. only a higher-level HTTP helper). **Mitigation:** throwaway spike as the first task;

--- a/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md
+++ b/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md
@@ -1,0 +1,240 @@
+# .NET Extension SDK — Design
+
+**Date:** 2026-06-19
+**Status:** Approved for planning
+**Authors:** MPT team (via Claude Code)
+
+## Summary
+
+The team is shifting SoftwareONE Marketplace extension development from the Python
+`mpt-extension-sdk` to a pure .NET implementation. This document designs a small set of
+reusable .NET libraries that a C# extension service can reference to get the same
+capabilities the Python SDK provides today: a typed Marketplace API client, an extension
+hosting/runtime model (instance registration, event/API routing, typed contexts,
+pipelines), and OpenZiti-based platform transport.
+
+The .NET libraries live in a **new, separate repository** (working name
+`mpt-extension-sdk-dotnet`). They target **net8.0 (LTS)** and ship as NuGet packages.
+
+## Goals
+
+- Provide a typed, ergonomic Marketplace API client for C# services (orders, agreements,
+  subscriptions, assets, products, installations, tasks, templates).
+- Reproduce the two-token auth model: a long-lived extension key for bootstrap, and
+  per-account JWT tokens that are minted, cached, and auto-refreshed.
+- Reproduce instance registration and identity persistence.
+- Provide an ASP.NET Core hosting model so a service can declare event/task handlers and
+  API endpoints, receive typed contexts, and process them through pipelines.
+- Connect to the platform over OpenZiti, matching today's `ziticorn` transport, while
+  keeping local development on plain Kestrel.
+
+## Non-Goals
+
+- Porting the Python `Plug` and `Schedule` route families. (`Plug` is declarative
+  metadata + static assets; `Schedule` is modeled but not mounted in the Python runtime.)
+  These can be added later; they are out of scope for the first deliverable.
+- Porting the Typer-based `mpt-ext` CLI. Metadata generation is provided as a library
+  capability and (optionally) a `dotnet` tool later.
+- A drop-in line-by-line port. We map Python concepts onto idiomatic .NET
+  (minimal-API/builder style, `HttpClient`, `IHostedService`, DI) rather than mirroring
+  Python class structure.
+
+## Reference: what the Python SDK does today
+
+The behaviours we are reproducing (verified against `mpt_extension_sdk/`):
+
+- **Registration** (`runtime/bootstrap/registration.py`): builds
+  `{externalId, version, meta}`, adds `channel: {}` when no matching identity exists, then
+  `POST /public/v1/integration/extensions/{extensionId}/instances` with a bearer extension
+  key. The response's `channel.identity` (OpenZiti credentials, keyed under `mrok`) is
+  persisted to an identity file.
+- **Transport** (`runtime/runner.py`): local mode runs `uvicorn`; platform mode calls
+  `register_instance()` then serves the ASGI app through `ziticorn.run(app, identityFile, …)`.
+- **API client** (`services/mpt_api_service/`): `MPTAPIService` wraps an async client and
+  exposes sub-services. Account scoping is done by an account-token provider that injects a
+  fresh per-account JWT on every request (60s refresh leeway, per-account lock).
+- **Routing** (`routing/`): `EventRouter` (event vs task delivery), `ApiRouter` (REST).
+- **Pipeline** (`pipeline/`): `BasePipeline`/`BaseStep` with `pre/process/post` lifecycle
+  and `Defer`/`Skip`/`Stop`/`Fail` control-flow signals; typed `OrderContext` /
+  `AgreementContext` built by a context factory from the inbound event.
+- **Auth** (`api/auth/`, `jwt.py`): extracts `Authorization: Bearer`, decodes (does not
+  verify — the gateway verifies) SoftwareONE claims
+  (`https://claims.softwareone.com/{accountId,accountType,extensionId,modules}`), checks
+  `exp` with a leeway.
+
+## Package architecture
+
+Three NuGet packages, split so the heavy/native Ziti dependency is isolated:
+
+```
+Swo.Mpt.ApiClient          (HttpClient only)
+        ▲
+        │
+Swo.Mpt.Extensions.Hosting (ASP.NET Core; depends on ApiClient)
+        ▲
+        │
+Swo.Mpt.Extensions.Ziti    (depends on Hosting + OpenZiti.NET)
+```
+
+A consuming service references:
+
+- `ApiClient` alone for pure outbound API access, **or**
+- `Hosting` to author an extension that runs on plain Kestrel (local dev), **or**
+- `Hosting` + `Ziti` for platform deployment over the Ziti overlay.
+
+### `Swo.Mpt.ApiClient`
+
+Mirrors `services/mpt_api_service`, `api/auth`, and `models`.
+
+- **Domain models**: records for Agreement, Order, Subscription, Asset, Product,
+  ProductItem, Installation, Task, Template, plus shared types (Account, Address, Contact,
+  Parameter, Price, Licensee, Authorization, ExternalId, Audit). System.Text.Json with
+  source-generated contexts.
+- **`IMptApiClient`** exposing sub-clients:
+  `Agreements`, `Orders`, `Subscriptions`, `Assets`, `Products`, `ProductItems`,
+  `Installations`, `Tasks`, `Templates`, `AccountTokens`.
+  Operations follow the Python services, e.g. `Orders.GetByIdAsync`, `Orders.CompleteAsync`,
+  `Orders.QueryAsync`, `Orders.FailAsync`, `Orders.UpdateAsync`;
+  `Agreements.GetAllAsync` (paginated), `GetByIdAsync`, `UpdateAsync`;
+  `Assets.CreateAsync` / `CreateOrderAssetAsync`; `Subscriptions.Create*`; etc.
+- **Pagination**: `PaginatedCollection<T> { Limit, Offset, Total, IReadOnlyList<T> Resources }`
+  with an `IAsyncEnumerable<T>` convenience wrapper for auto-paging.
+- **Auth**:
+  - `SoftwareOneJwt.ParseClaims(token)` — decode (not verify) claims; typed accessors for
+    accountId, accountType (`Client`/`Operations`/`Vendor`), extensionId, modules; expiry
+    check with leeway.
+  - `IAccountTokenProvider` — given an account id, returns a valid token, minting via
+    `POST /public/v1/integration/installations/token?account.id={id}` using the extension
+    key, caching per account, refreshing within a leeway window, serialized per-account.
+  - Two factory paths matching Python `from_config` (extension key) and
+    `from_auth_context` (account-scoped). Account scoping is implemented as a
+    `DelegatingHandler` that injects the fresh per-account token.
+- Configured through `IHttpClientFactory` + typed `MptApiOptions` (base URL, extension key,
+  timeouts). No ASP.NET Core dependency.
+
+### `Swo.Mpt.Extensions.Hosting`
+
+Mirrors `runtime`, `routing`, `pipeline`, `extension_app`. ASP.NET Core integration.
+
+- **Authoring API** (builder style over ASP.NET Core):
+  ```csharp
+  var builder = ExtensionApp.CreateBuilder(args);
+  builder.Events.OnTask("order.created", async (OrderContext ctx) => { ... });
+  builder.Events.OnEvent("agreement.updated", async (AgreementContext ctx) => { ... });
+  builder.Api.MapGet("/things/{id}", (ApiContext ctx, string id) => Results.Ok());
+  var app = builder.Build();
+  await app.RunAsync();
+  ```
+- **Contexts**: `ExtensionContext` (base: logger, `IMptApiClient`, settings, auth),
+  `EventContext` (+ event metadata, mutable state bag), `OrderContext` (+ `Order`,
+  `RefreshOrderAsync`), `AgreementContext` (+ `Agreement`, `RefreshAgreementAsync`),
+  `ApiContext` (+ request, auth). A context factory inspects the inbound event's object
+  type, fetches the Order/Agreement via the account-scoped client, and builds the right
+  typed context.
+- **Pipeline engine**: `IPipelineStep` with `PreAsync`/`ProcessAsync`/`PostAsync`
+  (`post` always runs); `Pipeline` runs steps sequentially; control-flow via exceptions
+  `DeferStepException`, `SkipStepException`, `StopStepException`, `FailException`. The event
+  handler maps these onto task lifecycle calls.
+- **Registration + lifecycle**: an `IHostedService` runs registration on startup
+  (build payload → POST instances → persist identity), then hands off to the configured
+  transport. Plain-Kestrel transport is the default in this package.
+- **Metadata**: generate `meta.yaml` (events and their metadata) before startup, matching
+  the Python `meta_config` contract.
+- **Request handling**: minimal-API endpoints that authenticate the JWT, build the
+  account-scoped client + typed context, invoke the handler/pipeline, and translate results
+  into task lifecycle calls (`Tasks.Start/Complete/Fail/Reschedule`). Correlation-id and
+  task-id headers flow through `Activity`/logging scope.
+
+### `Swo.Mpt.Extensions.Ziti`
+
+Mirrors `mrok`/`ziticorn`. Isolated native dependency (`OpenZiti.NET`).
+
+- Maps the persisted platform identity (`channel.identity`, the `mrok`-keyed JSON) to an
+  OpenZiti identity the SDK can load.
+- Provides the Ziti-bound server transport that replaces Kestrel's default TCP listener,
+  registered via `builder.UseZitiTransport()`.
+- **Target transport (B1):** a custom Kestrel `IConnectionListenerFactory` backed by an
+  `OpenZiti.NET` service binding, so inbound platform connections arrive over the overlay
+  in-process (app-embedded zero trust, single process — matches `ziticorn`).
+- **Documented fallback (B2):** a `ziti-edge-tunnel` sidecar exposes the service on
+  localhost and Kestrel binds localhost. Used only for bring-up if B1 is blocked.
+
+## Data flow
+
+**Startup (platform):**
+```
+Host start
+  → RegistrationHostedService
+      build {externalId, version, meta} (+ channel:{} if no matching identity)
+      POST /public/v1/integration/extensions/{extensionId}/instances  (Bearer extension key)
+      persist channel.identity → identity file
+  → Ziti transport binds Kestrel to the Ziti service using that identity
+  → ready
+```
+
+**Inbound event/task:**
+```
+Ziti overlay → Kestrel (Ziti transport) → minimal-API endpoint
+  authenticate JWT (parse claims, check exp)
+  resolve account-scoped IMptApiClient (account token via IAccountTokenProvider)
+  context factory: fetch Order/Agreement → build OrderContext/AgreementContext
+  Tasks.StartAsync(taskId)            (task delivery only)
+  run handler / pipeline
+    Defer  → Tasks.RescheduleAsync
+    Stop   → cancel
+    Fail   → Tasks.FailAsync
+    ok     → Tasks.CompleteAsync
+  return response
+```
+
+## Error handling
+
+- API client: typed `MptApiException` carrying status code + Marketplace error body;
+  transient-retry policy (e.g. via `Microsoft.Extensions.Http.Resilience`) on idempotent
+  reads and token minting.
+- Hosting: handler exceptions map to HTTP responses for API routes and to task lifecycle
+  outcomes for events; pipeline control-flow exceptions are first-class (not errors).
+- Registration: fail fast with a clear message on non-2xx; never start the transport
+  without an identity in platform mode.
+
+## Testing strategy
+
+- `ApiClient`: unit tests against a mocked `HttpMessageHandler` (request shape, auth header
+  injection, pagination, token caching/refresh/leeway, error mapping). No network.
+- `Hosting`: `WebApplicationFactory`-based tests on plain Kestrel — auth, context building,
+  handler dispatch, pipeline control-flow → task lifecycle mapping, registration payload.
+- `Ziti`: validated first by a **throwaway spike** (see Risks), then a thin integration
+  smoke test; the transport seam lets all `Hosting` tests run without Ziti.
+
+## Risks & open questions
+
+1. **Ziti-bound Kestrel transport (highest risk).** Must confirm `OpenZiti.NET` exposes a
+   `Stream`/socket-level server binding consumable by Kestrel's
+   `IConnectionListenerFactory`, rather than only a higher-level HTTP helper. **Mitigation:**
+   the first task in the implementation plan is a throwaway spike that stands up a Ziti
+   service binding feeding Kestrel and serves one request end-to-end. The rest of the design
+   assumes B1 but is gated on the spike; B2 (sidecar) is the fallback. The `Ziti` package
+   boundary makes the choice swappable without touching `Hosting`.
+2. **Native dependency / packaging.** `OpenZiti.NET` carries a native `ziti-sdk-c`
+   component (`OpenZiti.NET.native`); confirm Linux container + Windows dev support and RID
+   handling. Isolating it in one package limits blast radius.
+3. **Identity format mapping.** The platform returns identity under a `mrok` key; confirm
+   the exact JSON maps cleanly to what `OpenZiti.NET` loads (enrollment vs already-enrolled
+   identity).
+4. **`meta.yaml` schema fidelity.** Reproduce the Python `meta_config` output exactly so
+   the platform accepts the registration payload; pin against a captured sample.
+5. **JWT verification boundary.** Python decodes-without-verifying because the gateway
+   verifies. Confirm the same trust boundary holds for the .NET service behind Ziti.
+
+## Build sequence (high level — detailed plan follows)
+
+1. Ziti+Kestrel transport spike (resolve Risk 1) — throwaway.
+2. New repo + solution scaffold, CI, net8.0, NuGet metadata.
+3. `Swo.Mpt.ApiClient`: models → auth/JWT → account-token provider → sub-clients →
+   pagination → error handling, with tests.
+4. `Swo.Mpt.Extensions.Hosting`: contexts → builder/authoring API → registration hosted
+   service → event/API dispatch → pipeline engine → meta generation, on plain Kestrel,
+   with tests.
+5. `Swo.Mpt.Extensions.Ziti`: identity mapping → transport (B1, informed by the spike) →
+   integration smoke test.
+6. Sample/reference extension service + consumer docs.

--- a/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md
+++ b/docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md
@@ -1,25 +1,27 @@
 # Pure-.NET Extension SDK — Design
 
 **Date:** 2026-06-19
-**Status:** Draft for review (revised after discovering the existing bridge-based SDK and platform NuGet models)
+**Status:** Draft for review
 **Authors:** MPT team (via Claude Code)
 
 ## Summary
 
 The team is moving SoftwareONE Marketplace extension development to a **pure .NET**
-implementation. A bridge-based .NET SDK already exists at `C:\repos\mpt-extension-dotnet-sdk`
-(`Mpt.Extensions.Sdk`): it gives extension authors an attribute-driven model
-(`[EventHandler]`, `[ApiEndpoint]`, `[Plug]`, `[ScheduleHandler]`), typed contexts, a
-manifest source generator, and an `ExtensionHostBuilder` — but it delegates registration,
-OpenZiti transport, `meta.yaml`, and Marketplace API calls to a **Python bridge sidecar**.
+implementation. A bridge-based .NET SDK already exists in the work directory
+`C:\repos\mpt-extension-sdk-dotnet` (`Mpt.Extensions.Sdk`): it gives extension authors an
+attribute-driven model (`[EventHandler]`, `[ApiEndpoint]`, `[Plug]`, `[ScheduleHandler]`),
+typed contexts, a manifest source generator, and an `ExtensionHostBuilder` — but it delegates
+registration, OpenZiti transport, `meta.yaml`, and Marketplace API calls to a **Python bridge
+sidecar**.
 
-This design **removes the Python bridge** and reimplements its three responsibilities
-natively in .NET, while keeping the existing C# authoring surface. It also adopts the
-**platform domain models published on the PyraCloud NuGet feed**
-(`Mpt.Models.Platform`, `Mpt.Models.Core`) instead of bespoke/generated models.
+This design **removes the Python bridge** and reimplements its responsibilities natively in
+.NET, while keeping the existing C# authoring surface. The SDK stays **model-agnostic**: it
+ships no Marketplace domain models. The concrete extension chooses its own model types (the
+platform NuGet contracts, hand-written DTOs, or anything else) and passes them to the generic
+Marketplace client.
 
-The result is a small set of libraries a C# service references to build an extension with
-no Python in the container.
+The result is a small set of libraries a C# service references to build an extension with no
+Python in the container.
 
 ## Goals
 
@@ -32,12 +34,15 @@ no Python in the container.
   - **Direct, account-scoped Marketplace API access** (mint/cache/refresh account tokens,
     call the MPT API over Ziti), replacing the bridge `/__egress` proxy.
   - **Native `meta.yaml` generation** from the manifest, replacing the bridge's `meta.py`.
-- Reuse platform NuGet domain models (`Mpt.Models.Platform` / `Mpt.Models.Core`).
+- Keep the SDK **generic / model-agnostic** — no dependency on any Marketplace model package.
+  Provide a configurable serialization hook so an extension can deserialize into whatever model
+  types it uses.
 - Preserve local development without Ziti (plain Kestrel), mirroring today's local mode.
 
 ## Non-Goals
 
 - Rewriting the authoring model. The attribute/context/source-gen surface stays.
+- Shipping Marketplace domain models in the SDK. Models are the **extension's** choice.
 - Implementing `schedule` traffic end-to-end (routes exist but the platform doesn't drive
   them yet) or expanding `plug` beyond today's static-asset behaviour.
 - A managed-code OpenZiti reimplementation. We wrap `OpenZiti.NET` (which wraps `ziti-sdk-c`).
@@ -48,29 +53,33 @@ no Python in the container.
    contains the bridge-based SDK (`src/Mpt.Extensions.Sdk`, `bridge/`, `codegen`, `tests`,
    `tools`). The work: **keep the C# authoring SDK, drop the Python `bridge/`**, and add native
    registration/Ziti/egress. The separate GitHub-linked repo `C:\repos\mpt-extension-dotnet-sdk`
-   is left untouched for now.
+   is left untouched.
    - **Open item:** this directory has **no git remote**. A remote must be wired up before
-     publishing/CI (decide whether to push here or reconcile with the GitHub repo later).
-2. **Target framework: net10.0**, matching the existing `Mpt.Extensions.Sdk` and the
-   `product-hub-extension` POC. *(This supersedes the earlier net8.0 choice, which was made
-   before we knew the existing SDK and POC are net10.0. The platform models are net8.0 and
-   are consumable from net10.0.)*
-3. **Domain models: reuse `Mpt.Models.Platform` + `Mpt.Models.Core`** from the PyraCloud
-   feed. These are the published **Marketplace standard contracts**, so they are the correct
-   (de)serialization target for API responses — confirmed safe to use directly. The only
-   remaining mechanical step is pointing `MptJson` at the matching serializer options
-   (camelCase + any `Enumeration` converter the contract package ships); see Risk 1.
+     publishing/CI.
+2. **Target framework: net8.0 (LTS).** The existing `Mpt.Extensions.Sdk` and the
+   `product-hub-extension` POC are currently net10.0, so retargeting down to net8.0 may need
+   minor fixes (a plan task). net8.0 is the broad-compatibility LTS target for consuming
+   services.
+3. **Models: the SDK is model-agnostic.** It depends on **no** Marketplace model package. The
+   Marketplace client is generic (`GetAsync<T>/PostAsync<T>/PutAsync<T>`), and the consuming
+   extension supplies `T` — e.g. the platform NuGet contracts (`Mpt.Models.Platform`) or its own
+   DTOs. The SDK exposes a **configurable `JsonSerializerOptions`** so the extension can register
+   whatever converters its chosen models need (for platform contracts, e.g. a string↔`Enumeration`
+   converter). The SDK's own wire types (event envelope, auth claims, registration payload,
+   manifest) remain SDK-owned and need no external models.
 
 ## Existing assets we keep (from `Mpt.Extensions.Sdk`)
 
-Verified by reading the source:
+Verified by reading the source — all already model-agnostic:
 
 - **Attributes** (`Attributes/`): `EventHandlerAttribute` (`Event`, `Condition`, task flag),
   `ApiEndpointAttribute`, `PlugAttribute`, `ScheduleHandlerAttribute`.
 - **Contexts** (`Contexts/`): `IExtensionContext`, `EventContext` (carries `Event`,
   `AuthContext`, `IMarketplaceClient`, `ILogger`, `CancellationToken`), `ApiContext`,
-  `OrderContext`, `ScheduleContext`, `HandlerServices`.
-- **Events** (`Events/`): `Event`, `EventResponse` (`Ok` / `Delay(seconds)` / `Cancel(msg)`).
+  `OrderContext` (exposes only `OrderId` — a string), `ScheduleContext`, `HandlerServices`.
+- **Events** (`Events/`): `Event`/`EventObject`/`EventDetails`/`EventTask` (generic envelope,
+  ids + `objectType` string), `EventResponse` (`Ok` / `Delay(seconds)` / `Cancel(msg)`).
+- **Marketplace** (`Marketplace/`): generic `IMarketplaceClient`, `MarketplaceApiException`.
 - **Discovery + source-gen** (`Discovery/`, `Generated/`, the `SourceGen` project):
   `GeneratedHandlerRegistry` (reflection-free) with a reflection fallback.
 - **Manifest** (`Manifest/`): `ExtensionManifest`, `RouteDescriptor`, `RouteValidation`,
@@ -82,7 +91,7 @@ Verified by reading the source:
 
 ## What the bridge did that we must absorb (verified)
 
-The bridge sits between the platform and the C# host. Removing it means the SDK must take on:
+Removing the Python bridge means the SDK must take on:
 
 1. **Registration** — `POST {SDK_EXTENSION_URL}/public/v1/integration/extensions/{extensionId}/instances`
    with `Authorization: Bearer {extensionApiKey}` and body
@@ -100,7 +109,8 @@ The bridge sits between the platform and the C# host. Removing it means the SDK 
 4. **Egress** — today `IMarketplaceClient` POSTs `{Method, Path, Body, EgressSessionId}` to
    the bridge `/__egress`, which resolves the account-scoped token and calls the MPT API.
    Natively, a new `IMarketplaceClient` implementation must **call the MPT API directly over
-   Ziti and mint/cache/refresh the per-account token itself**.
+   Ziti and mint/cache/refresh the per-account token itself**, deserializing into the caller's
+   `T` with the configurable options.
 
 ## meta.yaml (ground truth from the POC)
 
@@ -129,14 +139,15 @@ registration — no host round-trip needed.
 
 ## Package architecture
 
-Three packages, isolating the native Ziti dependency:
+Three packages, isolating the native Ziti dependency. **None of them depend on any Marketplace
+model package** — models stay on the extension side.
 
 ```
-Swo.Mpt.Extensions.Abstractions   (the authoring surface; lifted from Mpt.Extensions.Sdk)
+Swo.Mpt.Extensions.Abstractions   (authoring surface; lifted from Mpt.Extensions.Sdk)
         ▲
         │
 Swo.Mpt.Extensions.Hosting        (ASP.NET Core host: endpoints, real-JWT auth, registration,
-        ▲                          direct MptApiClient, meta.yaml gen)
+        ▲                          generic account-scoped Marketplace client, meta.yaml gen)
         │
 Swo.Mpt.Extensions.Ziti           (OpenZiti transport; depends on Hosting + OpenZiti.NET)
 ```
@@ -147,14 +158,13 @@ Swo.Mpt.Extensions.Ziti           (OpenZiti transport; depends on Hosting + Open
 ### `Swo.Mpt.Extensions.Abstractions`
 
 The current `Mpt.Extensions.Sdk` authoring code, lifted with minimal change: attributes,
-`IExtensionContext`/`EventContext`/`ApiContext`/`OrderContext`/`ScheduleContext`, `Event`,
-`EventResponse`, `IMarketplaceClient`, manifest types, dispatch, discovery, source-gen.
-`AuthContext` is enriched to carry the decoded SoftwareONE claims (accountId, accountType,
-extensionId, modules) since the host now decodes the JWT itself.
+contexts, `Event`, `EventResponse`, generic `IMarketplaceClient`, manifest types, dispatch,
+discovery, source-gen. `AuthContext` is enriched to carry the decoded SoftwareONE claims
+(accountId, accountType, extensionId, modules) since the host now decodes the JWT itself.
 
 ### `Swo.Mpt.Extensions.Hosting` (the bulk of the new work)
 
-ASP.NET Core integration; depends on `Abstractions` + the platform model packages.
+ASP.NET Core integration; depends only on `Abstractions` (no model packages).
 
 - **`ExtensionHostBuilder.Build(builder)`** — unchanged authoring entrypoint; rewires the
   per-request pipeline to native auth + native Marketplace client and registers the hosted
@@ -163,14 +173,15 @@ ASP.NET Core integration; depends on `Abstractions` + the platform model package
   `X-Mpt-Auth` path — extract `Authorization: Bearer`, decode (not verify; the gateway
   verifies) claims `https://claims.softwareone.com/{accountId,accountType,extensionId,modules}`,
   check `exp` with leeway, build `AuthContext`. Bridge-token gate removed.
-- **`IMptApiClient` + account tokens**: a direct MPT API client (typed `HttpClient` via
-  `IHttpClientFactory`) that injects a fresh **account-scoped token** per request. An
+- **Generic Marketplace client + account tokens**: a direct MPT API client (typed `HttpClient`
+  via `IHttpClientFactory`) that injects a fresh **account-scoped token** per request. An
   `IAccountTokenProvider` mints tokens via
   `POST /public/v1/integration/installations/token?account.id={id}` using the extension key,
-  caches per account, and refreshes within a leeway window (serialized per account). This is
-  the native replacement for the bridge's egress + token resolver. The existing
-  `IMarketplaceClient` (generic `GetAsync<T>/PostAsync<T>/PutAsync<T>`) is reimplemented on
-  top of it, so handler code is unchanged.
+  caches per account, and refreshes within a leeway window (serialized per account). The existing
+  generic `IMarketplaceClient` (`GetAsync<T>/PostAsync<T>/PutAsync<T>`) is reimplemented on top
+  of it, so handler code is unchanged. Deserialization uses an **injectable `JsonSerializerOptions`**
+  (default: camelCase, case-insensitive); an extension using platform contracts registers any
+  needed converters (e.g. `Enumeration`) there.
 - **Registration hosted service**: on startup (platform mode) build the payload, POST
   instances, persist identity, then signal the transport. Fail fast on non-2xx; never start
   the Ziti transport without an identity.
@@ -191,7 +202,7 @@ Isolated `OpenZiti.NET` dependency.
   `builder.UseZitiTransport()`.
 - **Fallback (B2):** a `ziti-edge-tunnel` sidecar exposing the service on localhost, Kestrel
   binds localhost. Bring-up only.
-- Outbound (`IMptApiClient`) also dials the MPT API over the same Ziti context.
+- Outbound (the Marketplace client) also dials the MPT API over the same Ziti context.
 
 ## Data flow
 
@@ -215,9 +226,9 @@ Ziti overlay → Kestrel (Ziti transport) → mapped route (e.g. /events/...)
 
 **Egress (handler → Marketplace, no bridge):**
 ```
-ctx.Marketplace.GetAsync<OrderEntity>("/commerce/orders/ORD-...")
+ctx.Marketplace.GetAsync<TOrder>("/commerce/orders/ORD-...")   // TOrder is the EXTENSION's type
   → IMptApiClient: ensure fresh account token (IAccountTokenProvider) → HTTP over Ziti
-  → MPT API → deserialize into platform model
+  → MPT API → deserialize into TOrder using the configured JsonSerializerOptions
 ```
 
 ## Error handling
@@ -235,47 +246,44 @@ ctx.Marketplace.GetAsync<OrderEntity>("/commerce/orders/ORD-...")
   dispatch, discovery, manifest, route validation) on plain Kestrel via `WebApplicationFactory`.
 - Auth: JWT claims parsing, expiry leeway, account scoping.
 - Marketplace client: mocked `HttpMessageHandler` — request shape, token injection,
-  caching/refresh, error mapping, and **platform-model (de)serialization parity** (see Risk 1).
+  caching/refresh, error mapping, and correct deserialization into a caller-supplied `T` with a
+  custom converter (proving the serialization hook).
 - Registration: payload shape + identity persistence/reuse, asserted against the captured POC
   payload.
-- Ziti: validated by a **throwaway spike first** (Risk 2), then a thin integration smoke test.
+- Ziti: validated by a **throwaway spike first** (Risk 1), then a thin integration smoke test.
 
 ## Risks & open questions
 
-1. **Serializer options for the contract models (low risk — routine confirmation).**
-   The `Mpt.Models.Platform` types are the published Marketplace standard contracts and are
-   safe to deserialize into. The only thing to nail down is the `JsonSerializerOptions` they
-   expect: the types use PascalCase properties and `Enumeration`-typed fields
-   (`{Name, Id, AlternateNames}`), so the SDK's shared `MptJson` options must match the
-   contract's wire format (camelCase policy and an `Enumeration` (de)serialization converter —
-   reuse the one the contract/`Mpt.Models.Core` package ships if available, otherwise a small
-   `JsonConverterFactory` that maps the string name ↔ `Enumeration`). **Mitigation:** an early
-   task round-trips a couple of captured real responses (Order, Agreement) through the models
-   to lock the options in; expected to be a small, one-time configuration.
-2. **Ziti-bound Kestrel transport (highest delivery risk).** Confirm `OpenZiti.NET` exposes a
+1. **Ziti-bound Kestrel transport (highest delivery risk).** Confirm `OpenZiti.NET` exposes a
    `Stream`/socket-level server binding consumable by Kestrel's `IConnectionListenerFactory`
    (vs. only a higher-level HTTP helper). **Mitigation:** throwaway spike as the first task;
    B2 sidecar fallback; the `Ziti` package boundary makes the choice swappable.
-3. **Native dependency / packaging.** `OpenZiti.NET` carries a native `ziti-sdk-c` component;
-   confirm Linux-container + Windows-dev RID handling. Isolated in one package.
-4. **Identity format mapping.** Confirm the platform's `channel.identity` (`mrok`-keyed) maps
+2. **Native dependency / packaging.** `OpenZiti.NET` carries a native `ziti-sdk-c` component;
+   confirm Linux-container + Windows-dev RID handling, and net8.0 compatibility of the package.
+   Isolated in one package.
+3. **Identity format mapping.** Confirm the platform's `channel.identity` (`mrok`-keyed) maps
    cleanly to what `OpenZiti.NET` loads (already-enrolled identity vs enrollment JWT).
-5. **Repo strategy + history.** New repo (lift the reusable code) vs evolve the existing repo
-   (delete `bridge/`). Decision 1 above; confirm.
-6. **Auth verification boundary.** The bridge/gateway verified the JWT; confirm the same trust
+4. **net10 → net8 retarget.** The existing SDK/POC are net10.0; retargeting may surface
+   net10-only API usage to fix. Expected small.
+5. **Auth verification boundary.** The bridge/gateway verified the JWT; confirm the same trust
    boundary holds when the .NET host terminates Ziti directly (decode-not-verify stays valid).
+6. **Serialization ergonomics (extension-side, not SDK).** Extensions that use the platform
+   contracts need a string↔`Enumeration` converter + camelCase. Not an SDK dependency, but we
+   should document the recommended options and consider an **optional** tiny helper package
+   (e.g. `Swo.Mpt.Extensions.Contracts`) that ships those converters for convenience. YAGNI for
+   the first cut.
 
 ## Build sequence (high level — detailed plan follows)
 
-1. Ziti + Kestrel transport spike (resolve Risk 2) — throwaway.
-2. In `C:\repos\mpt-extension-sdk-dotnet`: ensure net10.0 + PyraCloud feed (`nuget.config`),
-   then remove the Python `bridge/` and its build wiring; keep the C# solution building.
+1. Ziti + Kestrel transport spike (resolve Risk 1) — throwaway.
+2. In `C:\repos\mpt-extension-sdk-dotnet`: retarget to net8.0, then remove the Python `bridge/`
+   and its build wiring; keep the C# solution building.
 3. Restructure the existing `Mpt.Extensions.Sdk` into the package split (Abstractions / Hosting /
    Ziti); keep its existing tests green throughout.
-4. `Swo.Mpt.Extensions.Hosting`: native JWT auth → account-token provider + `IMptApiClient`
-   (with platform-model serialization parity, Risk 1) → reimplement `IMarketplaceClient` on it
-   → registration hosted service → `meta.yaml` generation. Plain Kestrel; tests.
+4. `Swo.Mpt.Extensions.Hosting`: native JWT auth → account-token provider + account-scoped
+   Marketplace client (generic, injectable serializer options) → reimplement `IMarketplaceClient`
+   on it → registration hosted service → `meta.yaml` generation. Plain Kestrel; tests.
 5. `Swo.Mpt.Extensions.Ziti`: identity mapping → transport (B1, informed by the spike) →
    integration smoke test.
 6. Port `product-hub-extension` to the pure-.NET SDK as the reference/acceptance check (drop
-   the bridge, confirm parity against s1.show).
+   the bridge, supply its own models, confirm parity against s1.show).


### PR DESCRIPTION
## What

Adds the design spec and three implementation plans for moving SoftwareONE Marketplace extension development to a **pure-.NET** SDK, under `docs/superpowers/`:

- **Design spec** — `docs/superpowers/specs/2026-06-19-dotnet-extension-sdk-design.md`
- **Plan 1** — Foundation + native hosting (drop the Python bridge; native JWT auth, account-scoped Marketplace client, registration, `meta.yaml`)
- **Plan 2** — OpenZiti transport (`UseZiti()`, the .NET `ziticorn` equivalent)
- **Plan 3** — Migrate `product-hub-extension` onto the new SDK (acceptance check)

## Why

The team decided to replace the bridge-based approach (a C# host fronted by a Python `mrok`/`ziticorn` sidecar) with a single pure-.NET service. These documents capture the design decisions and the step-by-step, TDD-oriented plans that were used to build it.

## Scope / what a reviewer should know

- **This PR is documentation only.** The actual .NET SDK code does not live in this (Python) repository — it was implemented in a separate .NET repo following these plans.
- The plans were **executed and validated**: the SDK builds on net8.0 with 80 passing tests, and `product-hub-extension` was migrated onto it as an acceptance check (its handler + 9 tests pass against the new SDK with no code changes; the bundled source generator discovers the handler at runtime). The one item not verifiable without a live environment is the OpenZiti overlay bind, documented as a manual deployment smoke.
- Key resolved decisions recorded in the spec: net8.0 (LTS); model-agnostic SDK (extensions supply their own model types / platform contracts); reuse of the existing C# authoring surface; OpenZiti transport approach validated against both the OpenZiti .NET reference and the authoritative Python `mrok` source (bind service = `identity.mrok.extension`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Added Pure-.NET Extension SDK design specification documenting the removal of the Python bridge and native reimplementation of registration, OpenZiti transport, account-scoped Marketplace API access, and `meta.yaml` generation while preserving the existing C# attribute-driven authoring surface.

- Added Implementation Plan 1: Foundation and native hosting layer, detailing initialization of a net8.0 solution with ported Roslyn source generator, native JWT authentication, per-account token provider, direct Marketplace client, registration service, and local end-to-end sample extension.

- Added Implementation Plan 2: OpenZiti transport integration, specifying creation of `Mpt.Extensions.Sdk.Ziti` library with Ziti identity mapping, service naming derived from identity metadata, Kestrel listener factory integration via `UseZiti()` method, and manual deployment validation strategy.

- Added Implementation Plan 3: Migration acceptance workflow for `product-hub-extension` to validate the SDK, including package reference swaps, Ziti opt-in configuration, Docker containerization for pure-.NET deployment, and handler discovery via `__manifest` and `__health` endpoints.

- Documented key architectural decisions: net8.0 as target framework, model-agnostic SDK design with injectable serialization options, reuse of existing C# authoring surface, and validation of OpenZiti transport against both `OpenZiti.NET` reference implementation and authoritative Python `mrok` source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->