### PR TITLE
MPT-21910 normalize client models in from_payload and fix Address aliases

### DIFF
--- a/mpt_extension_sdk/models/address.py
+++ b/mpt_extension_sdk/models/address.py
@@ -6,9 +6,9 @@ from mpt_extension_sdk.models.base import BaseModel
 class Address(BaseModel):
     """Address model."""
 
-    address_line1: str = Field(serialization_alias="AddressLine1", validation_alias="AddressLine1")
+    address_line1: str = Field(serialization_alias="addressLine1", validation_alias="addressLine1")
     address_line2: str | None = Field(
-        default=None, serialization_alias="AddressLine2", validation_alias="AddressLine2"
+        default=None, serialization_alias="addressLine2", validation_alias="addressLine2"
     )
     city: str
     country: str

--- a/mpt_extension_sdk/models/base.py
+++ b/mpt_extension_sdk/models/base.py
@@ -31,4 +31,11 @@ class BaseModel(PydanticBaseModel):
     @classmethod
     def from_payload(cls, payload: Any) -> Self:
         """Build a model from an API payload."""
+        # mpt_api_client returns ModelBase objects (dicts exposed as dynamic attributes),
+        # whose nested values are also ModelBase. to_dict() turns them into plain nested
+        # dicts so fields typed as dict (e.g. ``module.settings``) validate as expected.
+        to_dict = getattr(payload, "to_dict", None)
+        if callable(to_dict):
+            payload = to_dict()
+
         return cls.model_validate(payload, by_alias=True)

--- a/tests/models/test_base.py
+++ b/tests/models/test_base.py
@@ -1,0 +1,112 @@
+import datetime as dt
+
+import pytest
+from pydantic import Field, ValidationError
+
+from mpt_extension_sdk.models.base import BaseModel
+
+
+class Nested(BaseModel):
+    amount: int = Field(serialization_alias="nestedValue", validation_alias="nestedValue")
+
+
+class Sample(BaseModel):
+    id: str
+    display_name: str | None = Field(
+        default=None, serialization_alias="displayName", validation_alias="displayName"
+    )
+    settings: dict = Field(default_factory=dict)
+    created: dt.datetime | None = None
+    nested: Nested | None = None
+
+
+class ModelWithToDict:
+    """Stub mimicking an mpt_api_client model: exposes ``to_dict``."""
+
+    def __init__(self, payload):
+        self._payload = payload
+
+    def to_dict(self):
+        return self._payload
+
+
+def test_to_dict_uses_aliases():
+    sample = Sample(id="1", display_name="Foo", nested=Nested(amount=5))
+
+    result = sample.to_dict()
+
+    assert result["displayName"] == "Foo"
+    assert result["nested"] == {"nestedValue": 5}
+
+
+def test_to_dict_excludes_none():
+    sample = Sample(id="1")
+
+    result = sample.to_dict()
+
+    assert result == {"id": "1", "settings": {}}
+
+
+def test_to_dict_serializes_in_json_mode():
+    created = dt.datetime(2026, 6, 22, 9, 0, tzinfo=dt.UTC)
+    sample = Sample(id="1", created=created)
+
+    result = sample.to_dict()
+
+    assert result["created"] == "2026-06-22T09:00:00Z"
+
+
+def test_from_payload_accepts_alias_keys():
+    payload = {"id": "1", "displayName": "Foo"}
+
+    result = Sample.from_payload(payload)
+
+    assert result.display_name == "Foo"
+
+
+def test_from_payload_accepts_name_keys():
+    payload = {"id": "1", "display_name": "Foo"}
+
+    result = Sample.from_payload(payload)
+
+    assert result.display_name == "Foo"
+
+
+def test_from_payload_normalizes_objects():
+    payload = ModelWithToDict({"id": "1", "displayName": "Foo", "settings": {"paid": False}})
+
+    result = Sample.from_payload(payload)
+
+    assert result.settings == {"paid": False}
+
+
+def test_from_payload_keeps_plain_dicts():
+    payload = {"id": "1", "settings": {"k": "v"}}
+
+    result = Sample.from_payload(payload)
+
+    assert result.settings == {"k": "v"}
+
+
+def test_from_payload_roundtrips():
+    nested = Nested(amount=5)
+    original = Sample(id="1", display_name="Foo", settings={"a": 1}, nested=nested)
+
+    result = Sample.from_payload(original.to_dict())
+
+    assert result == original
+
+
+def test_extra_keys_are_preserved():
+    payload = {"id": "1", "unknownKey": 123}
+
+    result = Sample.from_payload(payload)
+
+    assert result.model_extra == {"unknownKey": 123}
+
+
+def test_instances_are_frozen():
+    sample = Sample(id="1")
+
+    with pytest.raises(ValidationError):
+        sample.id = "2"


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

`BaseModel.from_payload` now normalizes `mpt_api_client` `Model` objects to a plain dict via `to_dict()` before validating. The client returns rich model objects whose nested values are themselves client models, so fields typed as `dict` (e.g. `module.settings`) received a nested model instead of a dict and raised a pydantic `dict_type` error.

Normalizing through `to_dict()` makes models validate from the canonical camelCase API keys. That surfaced two `Address` aliases declared in PascalCase (`AddressLine1` / `AddressLine2`); they are corrected to camelCase (`addressLine1` / `addressLine2`) so they match what the client emits.

Also adds unit tests for `BaseModel` covering `to_dict` and `from_payload` (client-object normalization, alias matching, extra-key preservation, and the `to_dict` round-trip).

## Why

Fetching extensions and agreements through the SDK services raised `ValidationError` — `dict_type` on `modules.*.settings`, and `Field required` on `licensee.address.addressLine1` — because client objects were passed straight into pydantic and nested client models were not coerced.

## Testing

`make check-all` passes: ruff, ruff format, flake8, mypy, and 343 tests (98% coverage).

MPT-21910


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-21910](https://softwareone.atlassian.net/browse/MPT-21910)

## Release Notes

- **Fixed Address field aliases**: Corrected `Address.address_line1` and `Address.address_line2` aliases from PascalCase (`AddressLine1`, `AddressLine2`) to camelCase (`addressLine1`, `addressLine2`) to match the canonical `mpt_api_client` API keys.
- **Enhanced BaseModel.from_payload()**: Updated `BaseModel.from_payload()` to normalize nested client model objects to plain dictionaries via `to_dict()` before pydantic validation, resolving dict-typed field validation errors when fetching extensions and agreements.
- **Added BaseModel unit tests**: Introduced tests covering `to_dict()`/`from_payload()` behavior, including client-object normalization, alias handling, extra-key preservation, round-trip equality, and immutability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21910]: https://softwareone.atlassian.net/browse/MPT-21910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ