### PR TITLE
MPT-22666 Document pending SDK usage topics in docs/sdk_usage

### DIFF
--- a/docs/sdk_usage/cli.md
+++ b/docs/sdk_usage/cli.md
@@ -1,0 +1,68 @@
+# CLI And Metadata
+
+The SDK ships the `mpt-ext` command (a Typer application) for the common
+developer tasks of running an extension and managing its metadata. Running an
+extension package built on the SDK exposes:
+
+```bash
+mpt-ext run --local
+mpt-ext run
+mpt-ext meta generate
+mpt-ext meta validate
+```
+
+## Running The Extension
+
+- `mpt-ext run --local` starts the local `FastAPI + uvicorn` runtime, intended
+  for development and debugging.
+- `mpt-ext run` starts the platform runtime (`mrok`/`ziticorn`): it builds
+  metadata, registers the extension instance, and serves the extension.
+
+## Metadata (`meta.yaml`)
+
+The metadata artifact is generated from `ExtensionApp` and the route decorators,
+so it stays in sync with the Python declarations and does not have to be
+maintained by hand. The generated document contains:
+
+- `openapi` — the OpenAPI path
+- `version` — the metadata version (default `1.0.0`)
+- `events` — one entry per event/task route (`event`, `condition`, `path`,
+  `task`)
+- `plugs` — one entry per registered plug, when the extension declares any
+
+```yaml
+openapi: /bypass/openapi.json
+version: 1.0.0
+events:
+  - event: platform.commerce.order.created
+    condition: "and(eq(type,Purchase),in(product.id,(PRD-5516-5707)))"
+    path: /api/v2/events/orders/purchase
+    task: true
+plugs:
+  - id: adobe
+    name: Adobe
+    description: Adobe widget
+    icon: /static/adobe.png
+    socket: commerce.agreements.agreement
+    href: /static/main-menu.js
+```
+
+### `mpt-ext meta generate`
+
+Writes `meta.yaml` from `ext_app.to_meta_config()`. Use it to (re)generate the
+checked-in metadata after changing routes or plugs.
+
+### `mpt-ext meta validate`
+
+Validates the extension metadata and exits non-zero on any failure. It:
+
+- validates that every plug `href` and `icon` resolves to an existing file under
+  the local `static/` folder
+- compares the checked-in `meta.yaml` against the metadata generated from the
+  extension app
+
+When validation fails, the command writes the freshly generated document to
+`meta.generated.yaml` next to `meta.yaml` so the difference can be inspected,
+and prints the reason. The CLI does not build frontend assets, validate
+JavaScript modules, or check that the public `/static` endpoint is reachable; it
+only validates the local static asset references declared by `PlugRouter`.

--- a/docs/sdk_usage/contexts-and-pipelines.md
+++ b/docs/sdk_usage/contexts-and-pipelines.md
@@ -40,10 +40,19 @@ async def process_order_change(event, context):
 You can also configure `context_adapter_type` once on the router and override
 it per route when needed.
 
+A derived context is the right place for extension-specific mutable state that
+must be carried across several steps in one execution — for example third-party
+objects cached during the flow, or helper properties that make the flow
+clearer. This keeps a clear separation between the immutable MPT snapshot
+(`ctx.order`), extension working state (derived attributes), and generic
+temporary state (`ctx.state`).
+
 ## Build A Processing Pipeline
 
 Use `BasePipeline`, `BaseStep`, and typed execution contexts for multi-step
-processing flows.
+processing flows. A handler chooses a pipeline, and the pipeline runs ordered
+business steps. The whole flow is readable in one place while each step stays
+focused on one unit of work.
 
 ```python
 from typing import override
@@ -70,3 +79,150 @@ class PurchasePipeline(BasePipeline):
 
 The SDK exports both `OrderContext` and `AgreementContext`, and the runtime
 hydrates the right one from `event.object.object_type`.
+
+## Step Lifecycle
+
+Each step runs through three lifecycle methods:
+
+- `pre(ctx)` — pre-processing hook (optional override).
+- `process(ctx)` — the business work. This is the only required override.
+- `post(ctx)` — post-processing hook (optional override).
+
+`post()` runs after `process()` both on success and on failure, so it is the
+place for cleanup or compensating actions. If both `process()` and `post()`
+raise, the `post()` exception is raised and chained from the original
+processing error.
+
+```python
+from typing import override
+
+from mpt_extension_sdk.errors.step import SkipStepError
+from mpt_extension_sdk.pipeline import BaseStep, OrderContext
+
+
+class ValidateDuplicateLines(BaseStep):
+    @override
+    async def pre(self, ctx: OrderContext) -> None:
+        if len(ctx.order.lines) <= 1:
+            raise SkipStepError("Order doesn't include more than one line.")
+
+    @override
+    async def process(self, ctx: OrderContext) -> None:
+        """Validate that the order has no duplicate lines."""
+```
+
+Steps read from `ctx.order` (or `ctx.agreement`) as an immutable input and must
+not mutate it. See [immutable-snapshots.md](immutable-snapshots.md) for the
+read/build/persist/refresh pattern.
+
+## Flow Control
+
+Steps express outcomes by raising typed step errors. The pipeline interprets
+them and continues, stops, or defers the flow:
+
+- `SkipStepError` — skip this step, continue the pipeline.
+- `StopStepError` — stop the pipeline with cancel semantics.
+- `DeferStepError` — stop the pipeline and defer for a later retry.
+
+See [error-handling.md](error-handling.md) for the full hierarchy and how each
+error maps to the event response.
+
+## Pipeline Hooks
+
+`BasePipeline` exposes hooks that react to each step's outcome, so shared
+behavior (status transitions, notifications, cleanup, extra logging) lives in
+one place instead of being duplicated in every step:
+
+- `on_step_succeeded(step, ctx)`
+- `on_step_skipped(step, ctx, error)`
+- `on_step_deferred(step, ctx, error)`
+- `on_step_stopped(step, ctx, error)`
+- `on_step_failed(step, ctx, error)`
+
+The defaults log the outcome. Override only the hooks relevant to your shared
+behavior — a common pattern is to keep success simple and centralize handling
+of stopped or failed outcomes. Call `super()` to preserve the default logging.
+
+```python
+from abc import ABC
+from typing import override
+
+from mpt_extension_sdk.errors.step import StopStepError
+from mpt_extension_sdk.pipeline import BasePipeline, BaseStep, OrderContext
+
+
+class OrderPipeline(BasePipeline, ABC):
+    @override
+    async def on_step_stopped(
+        self, step: BaseStep, ctx: OrderContext, error: StopStepError
+    ) -> None:
+        await super().on_step_stopped(step, ctx, error)
+        await self._handle_failure_action(ctx)
+
+    @override
+    async def on_step_failed(self, step: BaseStep, ctx: OrderContext, error: Exception) -> None:
+        await super().on_step_failed(step, ctx, error)
+        await self._handle_failure_action(ctx)
+
+    async def _handle_failure_action(self, ctx: OrderContext) -> None: ...
+```
+
+## Declaring Status Transitions
+
+When a step needs a Marketplace status transition, it should declare the intent
+on `ctx.order_state` (or `ctx.agreement_state`) and let a pipeline hook apply
+the shared side effect. This keeps steps focused on business intent while the
+hook owns the actual transition.
+
+`OrderStatusAction` is a frozen value object with:
+
+- `target_status` — an `OrderStatusActionType` (`FAIL` or `QUERY`)
+- `message`
+- `status_notes` (optional mapping)
+- `parameters` (optional mapping)
+
+`ctx.order_state` carries the declared `action` and a `handled` flag so a hook
+can apply the transition exactly once. (`AgreementStatusAction` and
+`agreement_state` mirror this, with `FAIL` as the only transition type.)
+
+```python
+from typing import override
+
+from mpt_extension_sdk.errors.step import StopStepError
+from mpt_extension_sdk.pipeline import (
+    BaseStep,
+    OrderContext,
+    OrderStatusAction,
+    OrderStatusActionType,
+)
+
+
+class ValidateDuplicateLines(BaseStep):
+    @override
+    async def process(self, ctx: OrderContext) -> None:
+        duplicates = self._get_duplicates(ctx.order.lines)
+        if duplicates:
+            ctx.order_state.action = OrderStatusAction(
+                target_status=OrderStatusActionType.FAIL,
+                message="Duplicate items found",
+                status_notes={"duplicates": ",".join(duplicates)},
+            )
+            raise StopStepError("Duplicate items found")
+```
+
+The matching pipeline hook reads `ctx.order_state.action`, applies the
+transition through `ctx.mpt_api_service`, and sets `handled = True`:
+
+```python
+async def _handle_failure_action(self, ctx: OrderContext) -> None:
+    if ctx.order_state.action is None or ctx.order_state.handled:
+        return
+
+    action = ctx.order_state.action
+    if action.target_status == OrderStatusActionType.FAIL:
+        await ctx.mpt_api_service.orders.fail(ctx.order_id, ...)
+    else:
+        await ctx.mpt_api_service.orders.query(ctx.order_id, ...)
+
+    ctx.order_state.handled = True
+```

--- a/docs/sdk_usage/error-handling.md
+++ b/docs/sdk_usage/error-handling.md
@@ -1,0 +1,110 @@
+# Error Handling
+
+The SDK centralizes runtime error mapping. Extension code expresses business
+intent by raising typed exceptions, and the SDK maps each one to the correct
+outcome: an event response for event/task routes, or a problem-details response
+for API routes. Extensions do not implement their own response mappers.
+
+This page covers the event/pipeline error model. For the API error model
+(`application/problem+json`, `APIError` subclasses, `422`/`500` responses) see
+[api.md](api.md).
+
+## Exception Hierarchy
+
+The SDK groups exceptions into three families.
+
+Runtime errors (`mpt_extension_sdk.errors.runtime`):
+
+- `ExtRuntimeError` — base runtime exception.
+  - `ConfigError` — invalid runtime or metadata configuration.
+  - `ValidationError` — a validation failure.
+
+Pipeline errors (`mpt_extension_sdk.errors.pipeline`):
+
+- `PipelineError` — base pipeline exception.
+  - `CancelError` — processing should be canceled.
+  - `DeferError` — processing should be retried later. Carries
+    `delay_seconds` (default `300`; must be greater than `0`).
+  - `FailError` — non-retriable failure outside the step-error model.
+
+Step errors (`mpt_extension_sdk.errors.step`):
+
+- `StepError` — base step exception.
+  - `SkipStepError` — skip the current step and continue the pipeline.
+  - `StopStepError` — stop the pipeline and cancel processing.
+  - `DeferStepError` — stop the pipeline and defer for a later retry. Carries
+    `delay_seconds` (default `300`).
+
+## Raising Errors From Steps
+
+In day-to-day flow logic you raise step errors. The pipeline translates them
+into pipeline errors and invokes the matching hook (see
+[contexts-and-pipelines.md](contexts-and-pipelines.md)):
+
+| Raised in a step | Pipeline hook | Result |
+| --- | --- | --- |
+| `SkipStepError` | `on_step_skipped` | step skipped, pipeline continues |
+| `StopStepError` | `on_step_stopped` | re-raised as `CancelError` |
+| `DeferStepError` | `on_step_deferred` | re-raised as `DeferError(delay_seconds)` |
+| any other `Exception` | `on_step_failed` | re-raised unchanged |
+
+Practical rules for extension authors:
+
+- raise `SkipStepError` when the current step does not apply
+- raise `StopStepError` when the pipeline should stop with cancel semantics
+- raise `DeferStepError` when third-party state is pending and the flow should be
+  retried later
+- raise `FailError` only when pipeline-level non-retriable failure semantics are
+  needed outside the step-error model
+
+```python
+from typing import override
+
+from mpt_extension_sdk.errors.step import DeferStepError, SkipStepError, StopStepError
+from mpt_extension_sdk.pipeline import BaseStep, OrderContext
+
+
+class SubmitVendorOrderStep(BaseStep):
+    @override
+    async def pre(self, ctx: OrderContext) -> None:
+        if not ctx.order.lines:
+            raise SkipStepError("Order has no lines to submit.")
+
+    @override
+    async def process(self, ctx: OrderContext) -> None:
+        result = await submit_to_vendor(ctx)
+        if result.is_rejected:
+            raise StopStepError("Vendor rejected the order.")
+        if result.is_pending:
+            raise DeferStepError("Vendor order still pending.", delay_seconds=600)
+```
+
+## Defining Custom Errors
+
+Extensions may subclass an SDK error to clarify business intent while keeping
+the same runtime behavior:
+
+```python
+from mpt_extension_sdk.errors.step import StopStepError
+
+
+class OrderFailedStopStepError(StopStepError):
+    pass
+```
+
+## Event Response Mapping
+
+For event and task routes, the SDK maps the final exception to an
+`EventResponse` through `map_exception_to_event_response`:
+
+| Exception | Event response |
+| --- | --- |
+| `CancelError` | `cancel(reason=...)` |
+| `DeferError` | `reschedule(seconds=delay_seconds)` |
+| `FailError` | `cancel(reason=...)` |
+| `ExtRuntimeError` | `cancel(reason="Runtime error")` |
+| any other exception | `cancel(reason="Unexpected error")` |
+
+Because `StopStepError` becomes `CancelError` and `DeferStepError` becomes
+`DeferError`, raising step errors is enough to drive the event outcome. You
+rarely need to construct `CancelError` or `DeferError` directly.

--- a/docs/sdk_usage/events.md
+++ b/docs/sdk_usage/events.md
@@ -53,3 +53,11 @@ received payload:
 This means a single extension app can register routes that receive either
 orders or agreements, and the SDK resolves the correct context family for each
 request at runtime.
+
+## Schedule Routes
+
+`ScheduleRouter` exists in the SDK contract and exposes a `schedule(path, name)`
+decorator, but scheduled routes are out of scope for the current phase: they are
+not yet mounted by the runtime nor emitted into the generated metadata. Treat
+`ScheduleRouter` as a forward-looking placeholder and do not rely on it for
+production flows yet.

--- a/docs/sdk_usage/immutable-snapshots.md
+++ b/docs/sdk_usage/immutable-snapshots.md
@@ -1,0 +1,80 @@
+# Immutable MPT Snapshots
+
+MPT models on the context (`ctx.order`, `ctx.agreement`, and their nested
+objects) must be treated as immutable snapshots of the current Marketplace
+state. Event-driven flows are retried, and hidden in-memory mutations make
+retries and later steps hard to reason about.
+
+The correct pattern is:
+
+1. read from `ctx.order` or `ctx.agreement`
+2. build a new payload explicitly
+3. persist it through `ctx.mpt_api_service`
+4. refresh only when later logic needs the updated representation
+
+Do not mutate the snapshot in place:
+
+```python
+# Avoid - mutating the snapshot
+ctx.order.parameters.set_fulfillment_value(...)
+ctx.order.external_ids.vendor = "..."
+line.price.unit_pp = new_price
+ctx.order.subscriptions.append(subscription)
+```
+
+## Updating Parameters
+
+The parameter bag exposes immutable helpers that return an updated copy instead
+of mutating in place:
+
+- `with_ordering_value(external_id, new_value)`
+- `with_fulfillment_value(external_id, new_value)`
+- `with_ordering_error(external_id, error)`
+- `with_fulfillment_error(external_id, error)`
+- `with_visibility(visible_params)`
+
+Read-only access uses `get_ordering_value(external_id)` and
+`get_fulfillment_value(external_id)`.
+
+```python
+updated_parameters = ctx.order.parameters.with_fulfillment_value("deploymentId", deployment_id)
+
+await ctx.mpt_api_service.orders.update(
+    ctx.order_id,
+    attributes={"parameters": updated_parameters.to_dict()},
+)
+```
+
+## Refreshing After A Write
+
+When later code in the same flow must read the updated Marketplace
+representation, refresh the snapshot explicitly. The SDK exposes two
+mechanisms for orders:
+
+- `await ctx.refresh_order()` reloads the canonical order from Marketplace.
+- `@refresh_order` is a convenience decorator that refreshes the order after a
+  step method returns successfully.
+
+```python
+from typing import override
+
+from mpt_extension_sdk.pipeline import BaseStep, OrderContext, refresh_order
+
+
+class CreateOrderSubscriptionsStep(BaseStep):
+    @override
+    @refresh_order
+    async def process(self, ctx: OrderContext) -> None:
+        await ctx.mpt_api_service.subscriptions.create_order_subscription(
+            ctx.order_id,
+            name="Example subscription",
+            lines=[{"id": ctx.order.lines[0].id}],
+        )
+```
+
+Agreement contexts expose the equivalent `await ctx.refresh_agreement()`
+method.
+
+Refresh adds an extra fetch, so use it only when the refreshed state is
+actually required by a later step — for example after creating subscriptions or
+assets inside an order. Do not refresh by default on every step.

--- a/docs/sdk_usage/observability.md
+++ b/docs/sdk_usage/observability.md
@@ -1,0 +1,113 @@
+# Observability
+
+The SDK owns tracing for the runtime and for pipeline execution. The baseline
+instrumentation (the tracing provider, FastAPI/`httpx`/logging hooks, and the
+pipeline and step spans) is wired through SDK hooks and middleware, so handlers,
+pipelines, and steps do not set up manual OpenTelemetry instrumentation
+themselves. Business code can still add its own child spans through the
+SDK-provided `trace_span` decorator (see below).
+
+## What The SDK Instruments
+
+When observability is enabled, the SDK bootstrap:
+
+- configures the process-wide `TracerProvider`
+- instruments the FastAPI app (inbound HTTP spans)
+- instruments `httpx` (outbound HTTP client spans)
+- instruments logging correlation, adding `trace_id` and `span_id` to log records
+
+On top of the standard HTTP spans, the SDK emits its own spans for pipeline and
+step execution:
+
+- pipeline spans named `pipeline: <PipelineName>`
+- step spans named `step: <StepName>`
+
+Both are enriched with event and business correlation attributes, including
+`mpt.event.id`, `mpt.task.id`, and the main business identifier (such as
+`order.id` or `agreement.id`).
+
+## Configuration
+
+Observability is controlled through runtime environment variables (see
+[configuration.md](../configuration.md)):
+
+- `SDK_OBSERVABILITY_ENABLED` enables or disables the bootstrap (default `true`).
+- `SDK_OTEL_SERVICE_NAME` overrides the reported service name.
+- `SDK_APPLICATIONINSIGHTS_CONNECTION_STRING` enables the Azure Monitor exporter
+  when set.
+
+The SDK always configures the OTLP exporter. When the Application Insights
+connection string is set, it additionally configures the Azure Monitor
+exporter. That exporter requires the optional dependency:
+
+```bash
+pip install "mpt-extension-sdk[azure-monitor]"
+```
+
+If the connection string is set but the optional dependency is missing, the SDK
+raises `ConfigError` with installation guidance.
+
+## Extension-Defined Spans
+
+The SDK creates a parent span around each route execution and propagates the
+active tracing context into the handler, so extension code can add child spans
+for business-specific operations. Use the `trace_span` decorator:
+
+```python
+from mpt_extension_sdk.observability import trace_span
+
+
+class AgreementSync:
+    @trace_span("adobe.sync_agreements")
+    async def execute(self, ctx) -> None:
+        agreements = await ctx.mpt_api_service.agreements.get_all()
+        for agreement in agreements:
+            await self.sync_agreement(ctx, agreement)
+
+    @trace_span(
+        "adobe.sync_agreement",
+        attributes={
+            "agreement.id": lambda self, ctx, agreement: agreement.id,
+        },
+    )
+    async def sync_agreement(self, ctx, agreement) -> None: ...
+```
+
+The first argument is the stable operation name shown in the trace tree.
+`attributes` add request-specific values for filtering and diagnostics; each
+value is either a static scalar or a callable evaluated from the decorated
+function's arguments. Only `bool`, `str`, `int`, and `float` results are
+recorded, and attribute resolution failures are skipped without breaking the
+call. `trace_span` works on both async and sync functions.
+
+## Adding Other Instrumentation
+
+If an extension needs additional dependency-specific instrumentation, declare it
+in the same `app.py` module where `ExtensionApp` is created — not inside
+handlers, pipelines, or steps. Keep the instrumentation call in an idempotent
+helper:
+
+```python
+from mpt_extension_sdk import ExtensionApp
+from opentelemetry.instrumentation.botocore import BotocoreInstrumentor
+
+ext_app = ExtensionApp(prefix="/api/v2")
+
+
+def instrument_dependencies() -> None:
+    """Register extra instrumentation. Safe to call more than once."""
+    BotocoreInstrumentor().instrument()
+```
+
+Be careful where you call it. `app.py` is imported to resolve `ext_app` during
+metadata generation (`mpt-ext meta generate` / `meta validate`), so calling
+`instrument_dependencies()` at module import time runs it during metadata
+generation too, which conflicts with the requirement to keep `app.py` imports
+deterministic and free of heavy side effects. Keep the helper idempotent and
+invoke it only when the runtime actually serves the extension.
+
+> **Note:** the SDK does not yet expose a first-class extension startup hook, so
+> there is currently no clean serve-time-only place to call this helper. A
+> dedicated `ExtensionApp.on_startup` hook is tracked in
+> [MPT-22678](https://softwareone.atlassian.net/browse/MPT-22678); this section
+> will be updated to use it once it lands.

--- a/docs/sdk_usage/settings.md
+++ b/docs/sdk_usage/settings.md
@@ -1,0 +1,112 @@
+# Settings
+
+The SDK separates configuration into three layers with different
+responsibilities. All three are injected into every execution context, so
+handlers, pipeline steps, and services read configuration from the context
+instead of loading environment variables directly.
+
+| Layer | Context attribute | Type | Owner |
+| --- | --- | --- | --- |
+| Runtime settings | `ctx.runtime_settings` | `RuntimeSettings` | SDK |
+| Extension settings | `ctx.ext_settings` | `ExtensionSettings` (your subclass) | Extension |
+| Account settings | `ctx.account_settings` | `AccountSettings` | Platform (future) |
+
+## Runtime Settings
+
+`RuntimeSettings` is SDK-owned, frozen, and loaded exclusively from environment
+variables. It carries infrastructure-level configuration such as the platform
+endpoints, local runtime host/port, observability flags, and the autodiscovered
+extension package modules.
+
+Extensions consume it read-only:
+
+```python
+log_level = ctx.runtime_settings.log_level
+extension_id = ctx.runtime_settings.extension_id
+```
+
+The process-wide singleton is available through `get_runtime_settings()` and is
+cached with `functools.lru_cache`. The required environment variables
+(`SDK_EXTENSION_URL`, `SDK_EXTENSION_API_KEY`, `SDK_EXTENSION_ID`,
+`MPT_API_BASE_URL`) are validated on load and raise `ConfigError` when missing.
+See [configuration.md](../configuration.md) for the full environment-variable
+reference.
+
+## Extension Settings
+
+Each extension defines its own settings model by subclassing
+`BaseExtensionSettings`. This is where vendor credentials, API base URLs,
+product mappings, and feature flags live.
+
+`settings.py` at the root of the extension package must export a class named
+`ExtensionSettings`. The SDK autodiscovers it, calls `ExtensionSettings.load()`,
+and caches the result for the process.
+
+```python
+# mock_app/settings.py
+import os
+from dataclasses import dataclass
+from typing import Self, override
+
+from mpt_extension_sdk.settings.extension import BaseExtensionSettings
+
+
+@dataclass(frozen=True)
+class ExtensionSettings(BaseExtensionSettings):
+    adobe_api_url: str
+    adobe_client_id: str
+    product_ids: list[str]
+
+    @override
+    @classmethod
+    def load(cls) -> Self:
+        return cls(
+            adobe_api_url=os.getenv("ADOBE_API_URL", ""),
+            adobe_client_id=os.getenv("ADOBE_CLIENT_ID", ""),
+            product_ids=cls.list_env("PRODUCT_IDS"),
+        )
+```
+
+Consume it from the context:
+
+```python
+product_ids = ctx.ext_settings.product_ids
+```
+
+### Environment-variable helpers
+
+`BaseExtensionSettings` inherits shared parsing helpers from `BaseSettings`. Use
+them inside `load()` instead of re-implementing parsing in business code:
+
+- `bool_env(key, *, default)` parses `true`/`1`/`yes` (case-insensitive) as
+  `True` and anything else as the boolean fallback.
+- `int_env(key, *, default)` parses an integer and raises `ConfigError` on an
+  invalid value.
+- `list_env(key, *, default="")` splits a comma-separated string into a trimmed
+  list, returning `[]` when unset.
+- `json_env(key, *, default="{}")` parses JSON objects, arrays, and scalars and
+  raises `ConfigError` on invalid JSON.
+
+### Required-variable validation
+
+Override `required_env_vars` to fail fast when a mandatory variable is missing.
+Each entry is a `(value, message)` tuple; `validate()` runs automatically after
+initialization and raises `ConfigError` listing every empty value.
+
+```python
+@property
+@override
+def required_env_vars(self) -> list[tuple[str, ...]]:
+    return [
+        (self.adobe_api_url, "ADOBE_API_URL is required"),
+        (self.adobe_client_id, "ADOBE_CLIENT_ID is required"),
+    ]
+```
+
+## Account Settings
+
+`account_settings` is an account-scoped layer reserved for customer-specific
+configuration that the platform model may provide in the future. The current
+`AccountSettings` is an empty placeholder, so `ctx.account_settings` is always
+present but carries no fields yet. Read from it for forward compatibility; do
+not depend on specific account-level fields until the platform exposes them.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,14 +9,27 @@ This guide is the entry point for building an extension package on top of
 - [Application setup](sdk_usage/application.md): install the SDK, shape an
   extension package, create `ExtensionApp`, include routers, and configure the
   runtime.
-- [Event routes](sdk_usage/events.md): register task and non-task event handlers.
+- [Event routes](sdk_usage/events.md): register task and non-task event handlers
+  (and the status of schedule routes).
 - [Authenticated API routes](sdk_usage/api.md): expose authenticated endpoints,
   validate bodies, read request/auth context, return API responses, and use
   pagination.
 - [UI plugs](sdk_usage/plugs.md): register `PlugRouter` providers and reference
   static assets.
 - [Contexts and pipelines](sdk_usage/contexts-and-pipelines.md): adapt execution
-  contexts and compose processing pipelines.
+  contexts, compose pipelines, drive the step lifecycle and flow control, use
+  pipeline hooks, and declare status transitions.
+- [Immutable snapshots](sdk_usage/immutable-snapshots.md): treat MPT models as
+  immutable, update parameters with the `with_*` helpers, and refresh after a
+  write.
+- [Error handling](sdk_usage/error-handling.md): raise typed step/pipeline
+  errors and let the SDK map them to event responses.
+- [Settings](sdk_usage/settings.md): the runtime, extension, and account
+  settings layers and the environment-variable helpers.
+- [Observability](sdk_usage/observability.md): SDK tracing, the
+  `azure-monitor` extra, and extension-defined spans with `trace_span`.
+- [CLI and metadata](sdk_usage/cli.md): the `mpt-ext` commands and `meta.yaml`
+  generation/validation.
 - [Marketplace services](sdk_usage/marketplace-services.md): use
   `ctx.mpt_api_service` from handlers and pipeline steps.
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Documents the SDK usage topics described in the SDK TDRs (phase 1 and phase 2) that were not yet covered under `docs/sdk_usage`.

New topic docs:
- `settings.md` — three-layer settings model (runtime / extension / account) and the `bool_env`/`int_env`/`list_env`/`json_env` helpers.
- `error-handling.md` — runtime/pipeline/step exception hierarchy and the event-response mapping.
- `immutable-snapshots.md` — immutable MPT snapshots, the parameter `with_*` helpers, and refresh (`ctx.refresh_order()` / `@refresh_order`).
- `observability.md` — SDK tracing, the `azure-monitor` extra, and `trace_span`.
- `cli.md` — the `mpt-ext` commands and `meta.yaml` generation/validation.

Expanded / updated docs:
- `contexts-and-pipelines.md` — added the step lifecycle (`pre`/`process`/`post`), flow control, pipeline hooks (`on_step_*`), and `OrderStatusAction`/`order_state`.
- `events.md` — added a `ScheduleRouter` status note (out of scope for the current phase).
- `usage.md` — wired all new topics into the navigation index.

## Notes

- Documentation reflects the current implementation, not the TDR where they diverge.
- Known TDR-vs-code discrepancies (`@refresh_agreement` decorator, `airtable` extra, `ctx.notifier`) are intentionally out of scope and tracked separately.

## Testing

Docs-only change. `pre-commit` hooks pass; no code paths affected.

Jira: MPT-22666


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-22666](https://softwareone.atlassian.net/browse/MPT-22666)

- Added new SDK usage docs for settings, error handling, immutable snapshots, observability, and CLI/metadata (`mpt-ext` and `meta.yaml` generation/validation).
- Updated contexts-and-pipelines docs with step lifecycle, typed flow control via step errors, pipeline hooks, and status transitions (`OrderStatusAction` / `order_state`).
- Updated events docs with a `ScheduleRouter` status note.
- Updated `docs/usage.md` to include the new SDK usage topics in the navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-22666]: https://softwareone.atlassian.net/browse/MPT-22666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ