### PR TITLE
MPT-21910 add Draft status to ExtensionStatusEnum for installations

### DIFF
--- a/mpt_extension_sdk/models/extension.py
+++ b/mpt_extension_sdk/models/extension.py
@@ -12,6 +12,7 @@ class ExtensionStatusEnum(StrEnum):
     """Extension status enum."""
 
     DELETED = "Deleted"
+    DRAFT = "Draft"
     PRIVATE = "Private"
     PUBLIC = "Public"
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Add `DRAFT` to `ExtensionStatusEnum` so that the SDK model reflects the draft state exposed by the MPT API for installations.

## Why

The MPT API returns `"Draft"` as a valid extension status for installations. Without this enum value, SDK consumers cannot match or handle the draft state in a type-safe way.

## Change

- `mpt_extension_sdk/models/extension.py`: add `DRAFT = "Draft"` to `ExtensionStatusEnum`

## Testing

- All 346 existing tests pass (`make check-all`)
- No new tests required: this is a pure enum value addition with no logic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Closes [MPT-21910](https://softwareone.atlassian.net/browse/MPT-21910)

- Added `DRAFT = "Draft"` to `ExtensionStatusEnum` in `mpt_extension_sdk/models/extension.py` so SDK consumers can type-safely handle the draft installation status returned by the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MPT-21910]: https://softwareone.atlassian.net/browse/MPT-21910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ