### PR TITLE
MPT-22771: rename release workflow to release.yml and add run-name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: Release (v${{ inputs.version }})
 
 # Manually-triggered release pipeline for this Python package. Runs against the
 # branch selected at dispatch time (main -> pre-release, release/* -> latest).


### PR DESCRIPTION
## What

- Renames the release workflow `on-release.yml` → `release.yml`.
- Adds the `run-name` property so each manually-dispatched run shows the version in its title:

```yaml
run-name: Release (v${{ inputs.version }})
```

## Why

- Consistent workflow filename (`release.yml`) across all mpt-/swo- repos.
- Run is labelled with the released version in the Actions UI.

## ⚠️ Action required before merge — PyPI trusted publisher

PyPI binds the OIDC trusted publisher to the **workflow filename**. After this rename, the project's PyPI trusted publisher must be updated from `on-release.yml` to `release.yml`, otherwise `uv publish` will fail OIDC authentication on the next release.

Jira: **MPT-22771** (parent MPT-21906)
