### PR TITLE
MPT-22875 Add /live and /ready operational endpoints

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,9 @@ The SDK runtime has two main execution surfaces:
 persists the returned identity when present, and starts the exported ASGI app through Ziticorn.
 `runtime/app.py` assembles the FastAPI app, configures middleware and observability,
 loads the extension's exported `ext_app`, and mounts every registered route.
+It also registers built-in operational endpoints: `/health` (status plus extension
+version), `/live` (liveness probe), and `/ready` (readiness probe, returning `503`
+until application startup completes and after shutdown begins).
 
 At the moment, `event` and `api` route families are implemented end-to-end in
 runtime request handling. Event routes are also emitted into `meta.yaml`. The

--- a/mpt_extension_sdk/runtime/app.py
+++ b/mpt_extension_sdk/runtime/app.py
@@ -1,9 +1,11 @@
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from importlib import import_module
 from pathlib import Path
 
-from fastapi import FastAPI, Request, Response
+from fastapi import FastAPI, Request, Response, status
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from mpt_extension_sdk.api.builders.api import create_api_route
@@ -99,14 +101,27 @@ def register_extension_routes(app: FastAPI, extension_app: ExtensionApp) -> None
 
 def _create_fastapi_app(extension_app: ExtensionApp) -> FastAPI:
     """Create the base FastAPI application for the extension runtime."""
-    return FastAPI(
+
+    @asynccontextmanager
+    async def runtime_lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: WPS430
+        """Mark the app as ready while the server is accepting traffic."""
+        app.state.ready = True
+        try:
+            yield
+        finally:
+            app.state.ready = False
+
+    app = FastAPI(
         title="MPT Extension API",
         description="MPT Extension API",
         version=extension_app.version,
         openapi_url=extension_app.openapi,
         docs_url="/bypass/docs",
         redoc_url="/bypass/redoc",
+        lifespan=runtime_lifespan,
     )
+    app.state.ready = False
+    return app
 
 
 def _configure_observability(app: FastAPI, observability_config: ObservabilityConfig) -> None:
@@ -144,3 +159,15 @@ def _register_builtin_routes(app: FastAPI) -> None:
     @app.get("/health", tags=["ops"])
     async def health() -> dict[str, str]:  # noqa: WPS430
         return {"status": "ok", "version": app.version}
+
+    @app.get("/live", tags=["ops"])
+    async def live() -> dict[str, str]:  # noqa: WPS430
+        return {"status": "ok"}
+
+    @app.get("/ready", tags=["ops"])
+    async def ready() -> JSONResponse:  # noqa: WPS430
+        if app.state.ready:
+            return JSONResponse({"status": "ok"})
+        return JSONResponse(
+            {"status": "unavailable"}, status_code=status.HTTP_503_SERVICE_UNAVAILABLE
+        )

--- a/tests/runtime/test_app.py
+++ b/tests/runtime/test_app.py
@@ -146,6 +146,34 @@ def test_create_runtime_app_registers_health(runtime_settings, runtime_app_patch
     assert response.json() == {"status": "ok", "version": extension_app.version}
 
 
+def test_create_runtime_app_registers_live(runtime_settings, runtime_app_patches):
+    result = runtime_app.create_runtime_app(runtime_settings)
+
+    response = TestClient(result).get("/live")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_ready_returns_unavailable_before_startup(runtime_settings, runtime_app_patches):
+    result = runtime_app.create_runtime_app(runtime_settings)
+
+    response = TestClient(result).get("/ready")
+    assert response.status_code == 503
+    assert response.json() == {"status": "unavailable"}
+
+
+def test_ready_follows_app_lifespan(runtime_settings, runtime_app_patches):
+    result = runtime_app.create_runtime_app(runtime_settings)
+
+    with TestClient(result) as client:
+        started_response = client.get("/ready")
+    stopped_response = TestClient(result).get("/ready")
+    assert started_response.status_code == 200
+    assert started_response.json() == {"status": "ok"}
+    assert stopped_response.status_code == 503
+    assert stopped_response.json() == {"status": "unavailable"}
+
+
 def test_create_runtime_app_registers_ext_routes(runtime_settings, runtime_app_patches):
     result = runtime_app.create_runtime_app(runtime_settings)
 


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Add built-in liveness and readiness endpoints to the extension runtime, next to the existing `/health` route:

- `GET /live`: liveness probe, returns `200 {"status": "ok"}` whenever the process is up and serving requests. No dependency checks.
- `GET /ready`: readiness probe that follows the FastAPI application lifespan. It returns `503 {"status": "unavailable"}` before startup completes and after shutdown begins, and `200 {"status": "ok"}` while the server accepts traffic.
- The readiness state is tracked with a new lifespan context manager in `_create_fastapi_app` that flips `app.state.ready` on startup/shutdown.
- `GET /health` stays unchanged for backward compatibility.
- The built-in operational endpoints are now documented in `docs/architecture.md`.

## Testing

- New unit tests in `tests/runtime/test_app.py` cover `/live`, `/ready` before startup, and the full lifespan cycle (ready while started, unavailable after shutdown).
- `make check-all` passes locally: formatting, ruff, flake8, mypy, lockfile check, and the full pytest suite (350 tests).

Jira: [MPT-22875](https://softwareone.atlassian.net/browse/MPT-22875)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MPT-22875]: https://softwareone.atlassian.net/browse/MPT-22875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Added built-in runtime operational endpoints: `/live` for liveness, `/ready` for readiness, while keeping `/health` unchanged for backward compatibility.
- Wired FastAPI lifespan state so readiness is `200 {"status":"ok"}` during startup/serving and `503 {"status":"unavailable"}` before startup and after shutdown.
- Documented the new operational endpoints in `docs/architecture.md`.
- Expanded runtime tests to cover `/live`, `/ready` before startup, and readiness behavior across the full lifespan cycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->