### PR TITLE
MPT-22887 Fix readiness lifespan crash under mrok proxy

### DIFF
--- a/mpt_extension_sdk/runtime/app.py
+++ b/mpt_extension_sdk/runtime/app.py
@@ -103,8 +103,13 @@ def _create_fastapi_app(extension_app: ExtensionApp) -> FastAPI:
     """Create the base FastAPI application for the extension runtime."""
 
     @asynccontextmanager
-    async def runtime_lifespan(app: FastAPI) -> AsyncIterator[None]:  # noqa: WPS430
-        """Mark the app as ready while the server is accepting traffic."""
+    async def runtime_lifespan(_lifespan_app: object) -> AsyncIterator[None]:  # noqa: WPS430
+        """Mark the app as ready while the server is accepting traffic.
+
+        Uses the closed-over FastAPI instance instead of the lifespan argument:
+        ASGI wrappers such as mrok's proxy pass their own wrapper object here,
+        which does not expose `state`.
+        """
         app.state.ready = True
         try:
             yield

--- a/tests/runtime/test_app.py
+++ b/tests/runtime/test_app.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import ModuleType
 
 import pytest
@@ -160,6 +161,19 @@ def test_ready_returns_unavailable_before_startup(runtime_settings, runtime_app_
     response = TestClient(result).get("/ready")
     assert response.status_code == 503
     assert response.json() == {"status": "unavailable"}
+
+
+async def _run_lifespan_with_wrapper(app: FastAPI) -> bool:
+    # mrok's proxy passes its own ASGIAppWrapper (without `state`) here
+    async with app.router.lifespan_context(object()):
+        return app.state.ready
+
+
+def test_lifespan_with_wrapper_argument():
+    result = runtime_app._create_fastapi_app(ExtensionApp())
+
+    assert asyncio.run(_run_lifespan_with_wrapper(result)) is True
+    assert result.state.ready is False
 
 
 def test_ready_follows_app_lifespan(runtime_settings, runtime_app_patches):


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Fix a startup crash in platform mode (mrok/ziticorn) introduced with the `/ready` readiness lifespan in SDK 6.4.3:

```
mrok.proxy ERROR 'ASGIAppWrapper' object has no attribute 'state'
```

- The `runtime_lifespan` in `_create_fastapi_app` named its parameter `app`, shadowing the FastAPI instance, so it set `app.state.ready` on whatever object the ASGI server passed to the lifespan. uvicorn passes the FastAPI app itself, so local mode worked, but mrok's proxy passes its own `ASGIAppWrapper` (from `scope["app"]`), which has no `state` attribute — crashing every platform-mode startup on 6.4.3.
- The lifespan now ignores its argument and flips the readiness flag on the closed-over FastAPI instance, so it works regardless of what the ASGI server passes in.
- Added a regression test that runs the lifespan with a wrapper-like object (no `state` attribute).

## Testing

- New regression test `test_lifespan_with_wrapper_argument` in `tests/runtime/test_app.py`.
- `make check-all` passes: formatting, ruff, flake8, mypy, lockfile and 351 tests.
- Verified manually through compose (`mpt-ext run`, mrok proxy): the startup error is gone and `/ready` behaves as expected.

Jira: [MPT-22887](https://softwareone.atlassian.net/browse/MPT-22887) (relates to MPT-22875)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MPT-22887]: https://softwareone.atlassian.net/browse/MPT-22887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ