### PR TITLE
MPT-22954 Authenticate account-scoped MPT client requests with the account token

### DIFF
--- a/mpt_extension_sdk/services/mpt_api_service/account_scoped_client.py
+++ b/mpt_extension_sdk/services/mpt_api_service/account_scoped_client.py
@@ -1,11 +1,11 @@
 import asyncio
 import datetime as dt
-from typing import TYPE_CHECKING, Any, ClassVar, Self, override
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING, ClassVar, override
 
-from mpt_api_client.auth import BearerTokenAuthentication
+from httpx import Request, Response, codes
+from mpt_api_client.auth import Authentication
 from mpt_api_client.http.async_client import AsyncHTTPClient
-from mpt_api_client.http.query_options import QueryOptions
-from mpt_api_client.http.types import HeaderTypes, QueryParam, RequestFiles, Response
 
 from mpt_extension_sdk.api.auth import AuthContext
 from mpt_extension_sdk.models.account import AccountToken
@@ -22,7 +22,7 @@ AccountLockCache = dict[AccountCacheKey, asyncio.Lock]
 TOKEN_EXPIRY_LEEWAY_SECONDS = 60
 
 
-class AccountTokenProvider:
+class AccountTokenProvider:  # noqa: WPS214
     """Account-scoped token cache with serialized refreshes per account."""
 
     _account_token_cache: ClassVar[AccountTokenCache] = {}
@@ -69,6 +69,20 @@ class AccountTokenProvider:
             self._store_token(cache_key, account_token)
             return account_token.token
 
+    def invalidate(self, token: str) -> None:
+        """Drop the cached account token when it matches a rejected one.
+
+        Only evicts the cache entry if it still holds the rejected token, so a fresh
+        token stored by a concurrent refresh is never discarded.
+
+        Args:
+            token: The bearer token rejected by the platform.
+        """
+        cache_key = self.cache_key
+        cached_token = self._account_token_cache.get(cache_key)
+        if cached_token is not None and cached_token.token == token:
+            self._account_token_cache.pop(cache_key, None)
+
     async def _fetch_account_token(self) -> AccountToken:
         mpt_api_service = self._service_type.from_config(
             base_url=self._runtime_settings.mpt_api_base_url,
@@ -91,78 +105,44 @@ class AccountTokenProvider:
             self._account_token_locks.pop(key, None)
 
 
-class AccountScopedAsyncHTTPClient(AsyncHTTPClient):
-    """HTTP client that injects a fresh account-scoped token before every request."""
+class AccountScopedAuthentication(Authentication):
+    """Authentication provider that signs requests with an account-scoped token."""
 
-    def __init__(
-        self,
-        *,
-        base_url: str,
-        bootstrap_api_token: str,
-        token_provider: AccountTokenProvider,
-        timeout: float = 60.0,
-    ) -> None:
-        super().__init__(
-            base_url=base_url,
-            authentication=BearerTokenAuthentication(bootstrap_api_token),
-            timeout=timeout,
-        )
+    # Buffer streamed request bodies before the auth flow so the 401 retry can
+    # resend them; one-shot streams would otherwise go out consumed or truncated.
+    requires_request_body = True
+
+    def __init__(self, token_provider: AccountTokenProvider) -> None:
         self._token_provider = token_provider
 
     @override
-    async def request(  # noqa: WPS211
-        self,
-        method: str,
-        url: str,
-        *,
-        files: RequestFiles | None = None,
-        json: Any | None = None,
-        query_params: QueryParam | None = None,
-        headers: HeaderTypes | None = None,
-        json_file_key: str = "_attachment_data",
-        force_multipart: bool = False,
-        options: QueryOptions | None = None,
-    ) -> Response:
-        """Perform a request using the current account-scoped token."""
-        request_headers = self._get_no_auth_headers(headers)
+    async def async_auth_flow(self, request: Request) -> AsyncGenerator[Request, Response]:
+        """Attach the current account-scoped bearer token, retrying once on 401.
+
+        A 401 response means the token was revoked before its expiry, so the cached
+        token is invalidated and the request is retried once with a fresh one.
+        """
         token = await self._token_provider.get_token()
-        request_headers["Authorization"] = f"Bearer {token}"
-        return await super().request(
-            method,
-            url,
-            files=files,
-            json=json,
-            query_params=query_params,
-            headers=request_headers,
-            json_file_key=json_file_key,
-            force_multipart=force_multipart,
-            options=options,
+        request.headers["Authorization"] = f"Bearer {token}"
+        response = yield request
+        if response.status_code == codes.UNAUTHORIZED:
+            self._token_provider.invalidate(token)
+            token = await self._token_provider.get_token()
+            request.headers["Authorization"] = f"Bearer {token}"
+            yield request
+
+
+def build_account_scoped_mpt_client(
+    *,
+    base_url: str,
+    token_provider: AccountTokenProvider,
+    timeout: float = 60.0,
+) -> AsyncMPTClient:
+    """Build an MPT client that authenticates requests with account-scoped tokens."""
+    return AsyncMPTClient(
+        AsyncHTTPClient(
+            base_url=base_url,
+            authentication=AccountScopedAuthentication(token_provider),
+            timeout=timeout,
         )
-
-    def _get_no_auth_headers(self, headers: HeaderTypes | None) -> HeaderTypes:
-        return {
-            key: header_value
-            for key, header_value in dict(headers or {}).items()
-            if key.lower() != "authorization"
-        }
-
-
-class AccountScopedAsyncMPTClient(AsyncMPTClient):
-    """MPT client that refreshes account-scoped tokens in the HTTP layer."""
-
-    @classmethod
-    def from_token_provider(
-        cls,
-        *,
-        base_url: str,
-        bootstrap_api_token: str,
-        token_provider: AccountTokenProvider,
-    ) -> Self:
-        """Create an account-scoped MPT client."""
-        return cls(
-            AccountScopedAsyncHTTPClient(
-                base_url=base_url,
-                bootstrap_api_token=bootstrap_api_token,
-                token_provider=token_provider,
-            )
-        )
+    )

--- a/mpt_extension_sdk/services/mpt_api_service/api_service.py
+++ b/mpt_extension_sdk/services/mpt_api_service/api_service.py
@@ -3,8 +3,8 @@ from typing import Self
 from mpt_extension_sdk.api.auth import AuthContext
 from mpt_extension_sdk.services.api_client_v2.mpt_api_client import AsyncMPTClient
 from mpt_extension_sdk.services.mpt_api_service.account_scoped_client import (
-    AccountScopedAsyncMPTClient,
     AccountTokenProvider,
+    build_account_scoped_mpt_client,
 )
 from mpt_extension_sdk.services.mpt_api_service.account_token import AccountTokenService
 from mpt_extension_sdk.services.mpt_api_service.agreement import AgreementService
@@ -49,13 +49,10 @@ class MPTAPIService:  # noqa: WPS215, WPS230
     async def from_auth_context(cls, base_url: str, auth: AuthContext) -> Self:
         """Create the service from the request authentication context."""
         runtime_settings = get_runtime_settings()
-        client = AccountScopedAsyncMPTClient.from_token_provider(
+        client = build_account_scoped_mpt_client(
             base_url=base_url,
-            bootstrap_api_token=runtime_settings.ext_api_key,
             token_provider=AccountTokenProvider(
-                runtime_settings=runtime_settings,
-                auth=auth,
-                service_type=cls,
+                runtime_settings=runtime_settings, auth=auth, service_type=cls
             ),
         )
         return cls(client)

--- a/tests/services/mpt_api_service/test_account_scoped.py
+++ b/tests/services/mpt_api_service/test_account_scoped.py
@@ -1,16 +1,18 @@
 import datetime as dt
+from collections.abc import AsyncIterator
+from contextlib import aclosing
+from functools import partial
 
 import pytest
-from mpt_api_client.http.async_client import AsyncHTTPClient
-from mpt_api_client.http.types import Response
+from httpx import AsyncClient, MockTransport, Request, Response, codes
 from mpt_api_client.resources.integration.installations_token import InstallationsToken
 
 from mpt_extension_sdk.api.auth import Account, AccountType, AuthContext
 from mpt_extension_sdk.models.account import AccountToken
 from mpt_extension_sdk.services.mpt_api_service.account_scoped_client import (
-    AccountScopedAsyncHTTPClient,
-    AccountScopedAsyncMPTClient,
+    AccountScopedAuthentication,
     AccountTokenProvider,
+    build_account_scoped_mpt_client,
 )
 from mpt_extension_sdk.services.mpt_api_service.account_token import AccountTokenService
 
@@ -96,46 +98,136 @@ async def test_provider_caches_token(
     installations.create_token.assert_awaited_once_with("ACC-1")
 
 
-def test_mpt_client_uses_refreshing_http_client(mocker):
+async def test_provider_invalidate_forces_refresh(
+    clear_account_token_cache, token_provider_factory
+):
+    provider, _, installations = token_provider_factory()
+    first_token = await provider.get_token()
+
+    provider.invalidate(first_token)
+
+    await provider.get_token()
+    assert installations.create_token.await_count == 2
+
+
+async def test_provider_invalidate_ignores_stale_token(
+    clear_account_token_cache, token_provider_factory
+):
+    provider, _, installations = token_provider_factory()
+    await provider.get_token()
+
+    provider.invalidate("already-replaced-token")
+
+    await provider.get_token()
+    installations.create_token.assert_awaited_once()
+
+
+def test_build_client_sets_account_authentication(mocker):
     token_provider = mocker.Mock(
         spec=["get_token"], get_token=mocker.AsyncMock(return_value="account-token")
     )
 
-    result = AccountScopedAsyncMPTClient.from_token_provider(
+    result = build_account_scoped_mpt_client(
         base_url="https://api.example.com",
-        bootstrap_api_token="extension-api-key",
         token_provider=token_provider,
     )
 
-    assert isinstance(result.http_client, AccountScopedAsyncHTTPClient)
+    assert isinstance(result.http_client.httpx_client.auth, AccountScopedAuthentication)
+    token_provider.get_token.assert_not_awaited()
 
 
-async def test_http_client_refreshes_each_request(mocker):
+async def test_authentication_refreshes_each_request(mocker):
     token_provider = mocker.Mock(
         spec=["get_token"],
         get_token=mocker.AsyncMock(side_effect=["account-token-1", "account-token-2"]),
     )
-    response = mocker.Mock(spec=Response)
-    request = mocker.patch.object(AsyncHTTPClient, "request", autospec=True, return_value=response)
-    client = AccountScopedAsyncHTTPClient(
-        base_url="https://api.example.com",
-        bootstrap_api_token="extension-api-key",
-        token_provider=token_provider,
-    )
+    authentication = AccountScopedAuthentication(token_provider)
 
     result = [
-        await client.request("get", "/orders/ORD-1", headers={"x-test": "1"}),
-        await client.request("get", "/orders/ORD-1", headers={"x-test": "1"}),
+        await _apply_authentication(
+            authentication,
+            Request("GET", "https://api.example.com/orders/ORD-1", headers={"x-test": "1"}),
+        ),
+        await _apply_authentication(
+            authentication,
+            Request("GET", "https://api.example.com/orders/ORD-1", headers={"x-test": "1"}),
+        ),
     ]
 
-    assert result == [response, response]
     assert token_provider.get_token.await_count == 2
-    assert request.await_count == 2
-    assert request.await_args_list[0].kwargs["headers"] == {
-        "x-test": "1",
-        "Authorization": "Bearer account-token-1",
-    }
-    assert request.await_args_list[1].kwargs["headers"] == {
-        "x-test": "1",
-        "Authorization": "Bearer account-token-2",
-    }
+    assert result[0].headers["Authorization"] == "Bearer account-token-1"
+    assert result[1].headers["Authorization"] == "Bearer account-token-2"
+    assert result[0].headers["x-test"] == "1"
+
+
+async def test_auth_flow_retries_once_on_unauthorized(mocker):
+    token_provider = mocker.Mock(
+        spec=["get_token", "invalidate"],
+        get_token=mocker.AsyncMock(side_effect=["revoked-token", "fresh-token"]),
+    )
+    authentication = AccountScopedAuthentication(token_provider)
+    auth_flow = authentication.async_auth_flow(
+        Request("GET", "https://api.example.com/orders/ORD-1")
+    )
+
+    first_authorization = (await anext(auth_flow)).headers["Authorization"]
+    retried_request = await auth_flow.asend(Response(codes.UNAUTHORIZED))
+
+    assert first_authorization == "Bearer revoked-token"
+    assert retried_request.headers["Authorization"] == "Bearer fresh-token"
+    token_provider.invalidate.assert_called_once_with("revoked-token")
+    with pytest.raises(StopAsyncIteration):
+        await auth_flow.asend(Response(codes.OK))
+
+
+async def test_auth_flow_retry_resends_streamed_body(mocker):
+    token_provider = mocker.Mock(
+        spec=["get_token", "invalidate"],
+        get_token=mocker.AsyncMock(side_effect=["revoked-token", "fresh-token"]),
+    )
+    received = []
+
+    async with AsyncClient(
+        transport=MockTransport(partial(_record_request, received)),
+        auth=AccountScopedAuthentication(token_provider),
+    ) as client:
+        response = await client.post("https://api.example.com/files", content=_stream_chunks())
+
+    assert response.status_code == codes.OK
+    assert received == [
+        ("Bearer revoked-token", b"chunk"),
+        ("Bearer fresh-token", b"chunk"),
+    ]
+
+
+async def test_auth_flow_does_not_retry_on_success(mocker):
+    token_provider = mocker.Mock(
+        spec=["get_token", "invalidate"],
+        get_token=mocker.AsyncMock(return_value="account-token"),
+    )
+    authentication = AccountScopedAuthentication(token_provider)
+    auth_flow = authentication.async_auth_flow(
+        Request("GET", "https://api.example.com/orders/ORD-1")
+    )
+
+    await anext(auth_flow)
+
+    with pytest.raises(StopAsyncIteration):
+        await auth_flow.asend(Response(codes.OK))
+    token_provider.invalidate.assert_not_called()
+
+
+async def _stream_chunks() -> AsyncIterator[bytes]:  # noqa: RUF029
+    yield b"chunk"
+
+
+def _record_request(received: list, request: Request) -> Response:
+    received.append((request.headers["Authorization"], request.content))
+    return Response(codes.UNAUTHORIZED if len(received) == 1 else codes.OK)
+
+
+async def _apply_authentication(
+    authentication: AccountScopedAuthentication, request: Request
+) -> Request:
+    async with aclosing(authentication.async_auth_flow(request)) as auth_flow:
+        return await anext(auth_flow)

--- a/tests/services/mpt_api_service/test_api_service.py
+++ b/tests/services/mpt_api_service/test_api_service.py
@@ -49,9 +49,8 @@ async def test_from_auth_context_uses_account_client(mocker, runtime_settings): 
         "mpt_extension_sdk.services.mpt_api_service.api_service.AccountTokenProvider",
         autospec=True,
     )
-    from_token_provider = mocker.patch(
-        "mpt_extension_sdk.services.mpt_api_service.api_service."
-        "AccountScopedAsyncMPTClient.from_token_provider",
+    build_account_scoped_mpt_client = mocker.patch(
+        "mpt_extension_sdk.services.mpt_api_service.api_service.build_account_scoped_mpt_client",
         autospec=True,
         return_value=client,
     )
@@ -64,8 +63,7 @@ async def test_from_auth_context_uses_account_client(mocker, runtime_settings): 
     token_provider.assert_called_once_with(
         runtime_settings=runtime_settings, auth=auth, service_type=MPTAPIService
     )
-    from_token_provider.assert_called_once_with(
+    build_account_scoped_mpt_client.assert_called_once_with(
         base_url="https://api.example.com",
-        bootstrap_api_token=runtime_settings.ext_api_key,
         token_provider=token_provider.return_value,
     )


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Fixes [MPT-22954](https://softwareone.atlassian.net/browse/MPT-22954): all requests built through `MPTAPIService.from_auth_context` were authenticated with the extension API key instead of the account-scoped token.

## Root cause

httpx applies the client's authentication flow at send time, after caller-supplied headers. `AccountScopedAsyncHTTPClient` injected the account token in its `request()` override, but the underlying client was built with `BearerTokenAuthentication(ext_api_key)`, whose `auth_flow` unconditionally rewrote the `Authorization` header — so every request went out with extension credentials. Streaming requests were not covered by the override at all.

## Fix

- Replace the `request()` override and bootstrap token with `AccountScopedAuthentication`, an httpx `Authentication` provider that fetches the token per request from the shared per-account cache (`AccountTokenProvider`). Being the auth layer itself, it cannot be overwritten and also covers `stream()`.
- On a `401 Unauthorized` response, invalidate the cached token and retry the request once with a fresh one, recovering from tokens revoked before their expiry. Invalidation only evicts the cache entry when it still holds the rejected token, so concurrent 401s never discard a freshly refreshed token.
- Replace `AccountScopedAsyncMPTClient.from_token_provider` with the `build_account_scoped_mpt_client` factory (no longer needs the extension bootstrap token).

## Testing

- New tests: provider invalidation (matching and stale token), 401 retry flow, no retry on success, per-request token refresh.
- `ruff format --check`, `ruff check`, `flake8`, `mypy` and the full test suite (355 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MPT-22954]: https://softwareone.atlassian.net/browse/MPT-22954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-22954](https://softwareone.atlassian.net/browse/MPT-22954)

- Switched account-scoped MPT client authentication to an `httpx` authentication provider (`AccountScopedAuthentication`) so the account token is attached per request and applies to streaming.
- Added per-request `401 Unauthorized` handling: invalidate the rejected token and retry exactly once with a freshly fetched token, using concurrency-safe cache invalidation.
- Replaced the old account-scoped client factories with `build_account_scoped_mpt_client`, removing the need for an extension bootstrap token in the HTTP layer.
- Updated `MPTAPIService.from_auth_context` to construct the account-scoped client via `build_account_scoped_mpt_client`.
- Expanded tests to cover token invalidation semantics, retry vs. no-retry behavior, auth header injection, and streamed body resend on retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->