### PR TITLE
MPT-22805 Introduce navigation-container plug type (no href) for nested navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,6 @@ make/local.mk
 # mrok
 *identity.json
 meta.yaml
+
+# Claude
+.claude

--- a/docs/sdk_usage/plugs.md
+++ b/docs/sdk_usage/plugs.md
@@ -38,3 +38,47 @@ under `/static/` in generated metadata, so `href="main-menu.js"` becomes
 `/static/main-menu.js` and `icon="images/icon.png"` becomes
 `/static/images/icon.png`. The `mpt-ext meta validate` command checks that every
 referenced file exists locally.
+
+## Nested navigation
+
+Use `NavigationPlug` to declare a pure navigation grouping node. A navigation
+container ships no bundle, so it has no `href`, and generated metadata omits the
+`href` key for it. Its `id` derives a nested socket (`<socket>.<id>`), exposed
+as `nested_socket`, under which child plugs mount:
+
+```python
+from mpt_extension_sdk import NavigationPlug, Plug, PlugRouter
+
+plug_router = PlugRouter()
+
+
+@plug_router.register()
+def register_plugs() -> list[Plug | NavigationPlug]:
+    learn_extensions = NavigationPlug(
+        id="learn-extensions",
+        name="Learn Extensions",
+        socket="portal",
+    )
+    return [
+        learn_extensions,
+        Plug(
+            id="guide",
+            name="Guide",
+            description="Extension guide",
+            socket=learn_extensions.nested_socket,  # portal.learn-extensions
+            href="guide.js",
+        ),
+        Plug(
+            id="examples",
+            name="Examples",
+            description="Extension examples",
+            socket=learn_extensions.nested_socket,
+            href="examples.js",
+        ),
+    ]
+```
+
+`NavigationPlug` accepts an optional `description` and `icon`; the icon is
+normalized under `/static/` like bundle plug assets. Passing an `href` to a
+navigation container raises an error — declare a `Plug` instead when the entry
+renders a bundle.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,8 +14,8 @@ This guide is the entry point for building an extension package on top of
 - [Authenticated API routes](sdk_usage/api.md): expose authenticated endpoints,
   validate bodies, read request/auth context, return API responses, and use
   pagination.
-- [UI plugs](sdk_usage/plugs.md): register `PlugRouter` providers and reference
-  static assets.
+- [UI plugs](sdk_usage/plugs.md): register `PlugRouter` providers, group plugs
+  under nested navigation containers, and reference static assets.
 - [Contexts and pipelines](sdk_usage/contexts-and-pipelines.md): adapt execution
   contexts, compose pipelines, drive the step lifecycle and flow control, use
   pipeline hooks, and declare status transitions.

--- a/mpt_extension_sdk/__init__.py
+++ b/mpt_extension_sdk/__init__.py
@@ -1,10 +1,18 @@
 from mpt_extension_sdk.extension_app import ExtensionApp
-from mpt_extension_sdk.routing import APIRouter, EventRouter, Plug, PlugRouter, ScheduleRouter
+from mpt_extension_sdk.routing import (
+    APIRouter,
+    EventRouter,
+    NavigationPlug,
+    Plug,
+    PlugRouter,
+    ScheduleRouter,
+)
 
 __all__ = [  # noqa: WPS410
     "APIRouter",
     "EventRouter",
     "ExtensionApp",
+    "NavigationPlug",
     "Plug",
     "PlugRouter",
     "ScheduleRouter",

--- a/mpt_extension_sdk/cli/main.py
+++ b/mpt_extension_sdk/cli/main.py
@@ -74,7 +74,8 @@ def validate_plug_static_assets(meta_config: MetaConfig, static_root: Path | Non
     """Validate local static assets referenced by registered plugs."""
     asset_root = static_root or Path.cwd() / "static"
     for plug in getattr(meta_config, "plugs", None) or []:
-        _validate_static_asset(plug.href, asset_root)
+        if plug.href is not None:
+            _validate_static_asset(plug.href, asset_root)
         if plug.icon is not None:
             _validate_static_asset(plug.icon, asset_root)
 

--- a/mpt_extension_sdk/routing/__init__.py
+++ b/mpt_extension_sdk/routing/__init__.py
@@ -6,7 +6,7 @@ from mpt_extension_sdk.routing.models import (
     PlugRouteDefinition,
     ScheduleRouteDefinition,
 )
-from mpt_extension_sdk.routing.plugs import STATIC_PATH_PREFIX, Plug
+from mpt_extension_sdk.routing.plugs import STATIC_PATH_PREFIX, NavigationPlug, Plug
 from mpt_extension_sdk.routing.routers.api import APIRouter
 from mpt_extension_sdk.routing.routers.base import BaseExtensionRouter
 from mpt_extension_sdk.routing.routers.event import EventRouter
@@ -26,6 +26,7 @@ __all__ = [  # noqa: WPS410
     "EventRouteDefinition",
     "EventRouter",
     "HTTPMethod",
+    "NavigationPlug",
     "Plug",
     "PlugRouteCallback",
     "PlugRouteDefinition",

--- a/mpt_extension_sdk/routing/plugs.py
+++ b/mpt_extension_sdk/routing/plugs.py
@@ -4,6 +4,33 @@ from pathlib import PurePosixPath
 STATIC_PATH_PREFIX = "/static/"
 
 
+def _normalize_static_path(path: str) -> str:
+    """Return a plug asset path rooted under the public static route."""
+    cleaned_path = path.strip()
+    if not cleaned_path:
+        raise ValueError("Plug static asset path cannot be empty")
+
+    static_root = STATIC_PATH_PREFIX.removesuffix("/")
+    if cleaned_path in {static_root, STATIC_PATH_PREFIX}:
+        raise ValueError("Plug static asset path must include a file")
+
+    if cleaned_path.startswith(STATIC_PATH_PREFIX):
+        relative_path = cleaned_path.removeprefix(STATIC_PATH_PREFIX)
+    else:
+        relative_path = cleaned_path.lstrip("/")
+
+    path_parts = PurePosixPath(relative_path).parts
+    if not path_parts or _has_invalid_path_parts(path_parts):
+        raise ValueError("Plug static asset path must stay under the static folder")
+
+    return STATIC_PATH_PREFIX + PurePosixPath(*path_parts).as_posix()
+
+
+def _has_invalid_path_parts(path_parts: tuple[str, ...]) -> bool:
+    """Return whether a static asset path contains unsafe parts."""
+    return bool({"", ".", ".."}.intersection(path_parts))
+
+
 @dataclass(frozen=True)
 class Plug:
     """UI plug metadata declared by an extension."""
@@ -19,36 +46,9 @@ class Plug:
     def __post_init__(self) -> None:
         """Validate and normalize static asset references."""
         self._validate_required_fields()
-        object.__setattr__(self, "href", self.normalize_static_path(self.href))
+        object.__setattr__(self, "href", _normalize_static_path(self.href))
         if self.icon is not None:
-            object.__setattr__(self, "icon", self.normalize_static_path(self.icon))
-
-    @classmethod
-    def normalize_static_path(cls, path: str) -> str:
-        """Return a plug asset path rooted under the public static route."""
-        cleaned_path = path.strip()
-        if not cleaned_path:
-            raise ValueError("Plug static asset path cannot be empty")
-
-        static_root = STATIC_PATH_PREFIX.removesuffix("/")
-        if cleaned_path in {static_root, STATIC_PATH_PREFIX}:
-            raise ValueError("Plug static asset path must include a file")
-
-        if cleaned_path.startswith(STATIC_PATH_PREFIX):
-            relative_path = cleaned_path.removeprefix(STATIC_PATH_PREFIX)
-        else:
-            relative_path = cleaned_path.lstrip("/")
-
-        path_parts = PurePosixPath(relative_path).parts
-        if not path_parts or cls._has_invalid_path_parts(path_parts):
-            raise ValueError("Plug static asset path must stay under the static folder")
-
-        return STATIC_PATH_PREFIX + PurePosixPath(*path_parts).as_posix()
-
-    @classmethod
-    def _has_invalid_path_parts(cls, path_parts: tuple[str, ...]) -> bool:
-        """Return whether a static asset path contains unsafe parts."""
-        return bool({"", ".", ".."}.intersection(path_parts))
+            object.__setattr__(self, "icon", _normalize_static_path(self.icon))
 
     def _validate_required_fields(self) -> None:
         """Validate required plug fields."""
@@ -64,3 +64,44 @@ class Plug:
                 raise ValueError(f"Plug {field_name} cannot be empty")
         if self.condition is not None and not self.condition.strip():
             raise ValueError("Plug condition cannot be empty")
+
+
+@dataclass(frozen=True)
+class NavigationPlug:
+    """Navigation-container plug that groups child plugs under a nested socket.
+
+    A navigation container ships no bundle, so it has no ``href``. Its ``id``
+    derives a nested socket (``<socket>.<id>``) that child plugs can target.
+    """
+
+    id: str
+    name: str
+    socket: str
+    description: str | None = None
+    icon: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate fields and normalize structural identifiers and the optional icon."""
+        self._validate_fields()
+        object.__setattr__(self, "id", self.id.strip())
+        object.__setattr__(self, "socket", self.socket.strip())
+        if self.icon is not None:
+            object.__setattr__(self, "icon", _normalize_static_path(self.icon))
+
+    @property
+    def nested_socket(self) -> str:
+        """Derived socket that child plugs target to mount under this container."""
+        return f"{self.socket}.{self.id}"
+
+    def _validate_fields(self) -> None:
+        """Validate navigation plug fields."""
+        required_fields = {
+            "id": self.id,
+            "name": self.name,
+            "socket": self.socket,
+        }
+        for field_name, field_value in required_fields.items():
+            if not field_value.strip():
+                raise ValueError(f"Navigation plug {field_name} cannot be empty")
+        if self.description is not None and not self.description.strip():
+            raise ValueError("Navigation plug description cannot be empty")

--- a/mpt_extension_sdk/routing/types.py
+++ b/mpt_extension_sdk/routing/types.py
@@ -1,10 +1,10 @@
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from mpt_extension_sdk.routing.plugs import Plug
+    from mpt_extension_sdk.routing.plugs import NavigationPlug, Plug
 
 RouteCallback = Callable[..., Awaitable[Any] | Any]
 EventRouteCallback = Callable[..., Awaitable[None] | None]
 APIRouteCallback = Callable[..., Awaitable[object] | object]
-PlugRouteCallback = Callable[[], list["Plug"]]
+PlugRouteCallback = Callable[[], Sequence["Plug | NavigationPlug"]]

--- a/mpt_extension_sdk/runtime/bootstrap/registration.py
+++ b/mpt_extension_sdk/runtime/bootstrap/registration.py
@@ -21,7 +21,7 @@ def register_instance(settings: RuntimeSettings) -> RegistrationResult:
     payload: dict[str, Any] = {
         "externalId": settings.external_id,
         "version": settings.meta_config.version,
-        "meta": settings.meta_config.model_dump(by_alias=True),
+        "meta": settings.meta_config.model_dump(exclude_none=True, by_alias=True),
     }
     logger.info(
         "Registering extension instance extension_id=%s external_id=%s \n events: %s",

--- a/mpt_extension_sdk/runtime/builders.py
+++ b/mpt_extension_sdk/runtime/builders.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 
 from mpt_extension_sdk.routing.models import BaseRouteDefinition, PlugRouteDefinition
-from mpt_extension_sdk.routing.plugs import Plug
+from mpt_extension_sdk.routing.plugs import NavigationPlug, Plug
 from mpt_extension_sdk.runtime.models import MetaPlug
 
 
@@ -21,8 +21,19 @@ class PlugMetadataBuilder:
             meta_plugs.append(self._create_meta_plug(plug))
         return meta_plugs
 
-    def _create_meta_plug(self, plug: Plug) -> MetaPlug:
-        """Create a runtime metadata plug from a declared plug."""
+    def _create_meta_plug(self, plug: Plug | NavigationPlug) -> MetaPlug:
+        """Create a runtime metadata plug from a declared plug.
+
+        Navigation-container plugs carry no bundle, so their metadata has no `href`.
+        """
+        if isinstance(plug, NavigationPlug):
+            return MetaPlug(
+                id=plug.id,
+                name=plug.name,
+                description=plug.description,
+                icon=plug.icon,
+                socket=plug.socket,
+            )
         return MetaPlug(
             id=plug.id,
             name=plug.name,
@@ -41,14 +52,14 @@ class PlugMetadataBuilder:
                 plugs.extend(route.callback())
         return plugs
 
-    def _validate_plug(self, plug: object) -> Plug:
+    def _validate_plug(self, plug: object) -> Plug | NavigationPlug:
         """Validate plug provider output."""
-        if not isinstance(plug, Plug):
-            raise TypeError("Plug providers must return Plug instances")
+        if not isinstance(plug, Plug | NavigationPlug):
+            raise TypeError("Plug providers must return Plug or NavigationPlug instances")
         self._validate_unique_plug_id(plug)
         return plug
 
-    def _validate_unique_plug_id(self, plug: Plug) -> None:
+    def _validate_unique_plug_id(self, plug: Plug | NavigationPlug) -> None:
         """Validate that a plug id has not already been declared."""
         if plug.id in self._plug_ids:
             raise ValueError(f"Plug id '{plug.id}' is already registered")

--- a/mpt_extension_sdk/runtime/models.py
+++ b/mpt_extension_sdk/runtime/models.py
@@ -20,16 +20,20 @@ class MetaEvent(BaseModel):
 
 
 class MetaPlug(BaseModel):
-    """MetaPlug model for loading metadata."""
+    """MetaPlug model for loading metadata.
+
+    Navigation-container plugs ship no bundle, so `href` always stays unset;
+    `description` is optional and may be populated when the container declares one.
+    """
 
     # Keep the order of fields in the model consistent with the order in the metadata file
     id: str = Field(min_length=1)
     name: str = Field(min_length=1)
-    description: str = Field(min_length=1)
+    description: str | None = Field(default=None, min_length=1)
     icon: str | None = Field(default=None, min_length=1)
     socket: str = Field(min_length=1)
     condition: str | None = Field(default=None, min_length=1)
-    href: str = Field(min_length=1)
+    href: str | None = Field(default=None, min_length=1)
 
     model_config = ConfigDict(extra="forbid")
 

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -161,6 +161,48 @@ def test_validate_plug_assets_rejects_traversal(plug_meta, tmp_path):
         validate_plug_static_assets(plug_meta, tmp_path / "static")
 
 
+def test_validate_assets_skips_container_href(tmp_path):
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    (static_dir / "learn.png").write_text("icon", encoding="utf-8")
+    container_meta = MetaConfig(
+        version="1.0.0",
+        openapi="/bypass/openapi.json",
+        events=[],
+        plugs=[
+            MetaPlug(
+                id="learn-extensions",
+                name="Learn Extensions",
+                icon="/static/learn.png",
+                socket="portal",
+            )
+        ],
+    )
+
+    validate_plug_static_assets(container_meta, static_dir)  # act
+
+
+def test_validate_assets_checks_container_icon(tmp_path):
+    static_dir = tmp_path / "static"
+    static_dir.mkdir()
+    container_meta = MetaConfig(
+        version="1.0.0",
+        openapi="/bypass/openapi.json",
+        events=[],
+        plugs=[
+            MetaPlug(
+                id="learn-extensions",
+                name="Learn Extensions",
+                icon="/static/missing.png",
+                socket="portal",
+            )
+        ],
+    )
+
+    with pytest.raises(ConfigError, match="Plug asset file was not found"):
+        validate_plug_static_assets(container_meta, static_dir)
+
+
 def test_validate_generates_missing_meta_file(
     runtime_settings_factory, cli_runner, mocker, tmp_path
 ):

--- a/tests/routing/routers/test_plug.py
+++ b/tests/routing/routers/test_plug.py
@@ -2,7 +2,23 @@ from collections.abc import Callable
 
 import pytest
 
-from mpt_extension_sdk.routing import Plug, PlugRouter, RouteType
+from mpt_extension_sdk.routing import NavigationPlug, Plug, PlugRouter, RouteType
+
+
+@pytest.fixture
+def list_plug_provider() -> Callable[[], list[Plug]]:
+    def factory() -> list[Plug]:
+        return [
+            Plug(
+                id="adobe",
+                name="Adobe",
+                description="Adobe widget",
+                socket="commerce.agreements.agreement",
+                href="main-menu.js",
+            )
+        ]
+
+    return factory
 
 
 def test_plug_normalizes_static_asset_paths():
@@ -44,6 +60,63 @@ def test_plug_rejects_static_root_path(href):
         )
 
 
+def test_navigation_plug_normalizes_icon_path():
+    result = NavigationPlug(
+        id="learn-extensions",
+        name="Learn Extensions",
+        socket="portal",
+        description="Learning resources",
+        icon="assets/learn.png",
+    )
+
+    assert result.icon == "/static/assets/learn.png"
+    assert result.description == "Learning resources"
+
+
+def test_navigation_plug_derives_nested_socket():
+    result = NavigationPlug(id="learn-extensions", name="Learn Extensions", socket="portal")
+
+    assert result.nested_socket == "portal.learn-extensions"
+
+
+def test_navigation_plug_strips_id_and_socket():
+    result = NavigationPlug(id=" learn-extensions ", name="Learn Extensions", socket=" portal ")
+
+    assert (result.id, result.socket) == ("learn-extensions", "portal")
+    assert result.nested_socket == "portal.learn-extensions"
+
+
+@pytest.mark.parametrize("field_name", ["id", "name", "socket"])
+def test_navigation_plug_rejects_empty_fields(field_name):
+    plug_fields = {"id": "learn-extensions", "name": "Learn Extensions", "socket": "portal"}
+    plug_fields[field_name] = "  "
+
+    with pytest.raises(ValueError, match=f"Navigation plug {field_name} cannot be empty"):
+        NavigationPlug(**plug_fields)
+
+
+def test_navigation_plug_blank_description_fails():
+    with pytest.raises(ValueError, match="Navigation plug description cannot be empty"):
+        NavigationPlug(
+            id="learn-extensions",
+            name="Learn Extensions",
+            socket="portal",
+            description=" ",
+        )
+
+
+def test_navigation_plug_rejects_href():
+    plug_fields = {
+        "id": "learn-extensions",
+        "name": "Learn Extensions",
+        "socket": "portal",
+        "href": "main-menu.js",
+    }
+
+    with pytest.raises(TypeError, match="unexpected keyword argument 'href'"):
+        NavigationPlug(**plug_fields)
+
+
 def test_plug_router_registers_provider(mocker):
     router = PlugRouter(prefix="/plug")
     plug_provider = mocker.Mock(
@@ -69,3 +142,12 @@ def test_plug_router_registers_provider(mocker):
         RouteType.PLUG,
     )
     assert route.callback() == plug_provider()
+
+
+def test_plug_router_accepts_list_plug_provider(list_plug_provider: Callable[[], list[Plug]]):
+    router = PlugRouter(prefix="/plug")
+
+    result = router.register()(list_plug_provider)  # act
+
+    assert result is list_plug_provider
+    assert router.routes[0].callback() == list_plug_provider()

--- a/tests/runtime/bootstrap/test_registration.py
+++ b/tests/runtime/bootstrap/test_registration.py
@@ -37,7 +37,9 @@ def test_register_instance_adds_channel(runtime_settings, registration_patches, 
     payload = register_extension_instance.call_args.args[3]
     assert payload["externalId"] == runtime_settings.external_id
     assert payload["version"] == runtime_settings.meta_config.version
-    assert payload["meta"] == runtime_settings.meta_config.model_dump(by_alias=True)
+    assert payload["meta"] == runtime_settings.meta_config.model_dump(
+        exclude_none=True, by_alias=True
+    )
     assert payload["channel"] == {}
     save_identity.assert_not_called()
 

--- a/tests/runtime/test_builders.py
+++ b/tests/runtime/test_builders.py
@@ -1,4 +1,6 @@
-from mpt_extension_sdk.routing import Plug, PlugRouteDefinition, RouteType
+import pytest
+
+from mpt_extension_sdk.routing import NavigationPlug, Plug, PlugRouteDefinition, RouteType
 from mpt_extension_sdk.runtime.builders import PlugMetadataBuilder
 
 
@@ -29,3 +31,57 @@ def test_plug_metadata_builder_reuse(mocker):
     result = plug_metadata_builder.build()  # act
 
     assert first_result == result
+
+
+def test_builder_emits_navigation_plug_no_href(mocker):
+    plug_provider = mocker.Mock(
+        return_value=[
+            NavigationPlug(id="learn-extensions", name="Learn Extensions", socket="portal")
+        ]
+    )
+    plug_metadata_builder = PlugMetadataBuilder(
+        routes=[
+            PlugRouteDefinition(
+                name="plug-provider",
+                path="/plug-provider",
+                route_type=RouteType.PLUG,
+                callback=plug_provider,
+            )
+        ]
+    )
+
+    result = plug_metadata_builder.build()
+
+    assert result[0].model_dump(exclude_none=True) == {
+        "id": "learn-extensions",
+        "name": "Learn Extensions",
+        "socket": "portal",
+    }
+
+
+def test_builder_rejects_duplicate_id_mixed_types(mocker):
+    plug_provider = mocker.Mock(
+        return_value=[
+            NavigationPlug(id="adobe", name="Adobe Group", socket="portal"),
+            Plug(
+                id="adobe",
+                name="Adobe",
+                description="Adobe widget",
+                socket="portal.adobe",
+                href="main-menu.js",
+            ),
+        ]
+    )
+    plug_metadata_builder = PlugMetadataBuilder(
+        routes=[
+            PlugRouteDefinition(
+                name="plug-provider",
+                path="/plug-provider",
+                route_type=RouteType.PLUG,
+                callback=plug_provider,
+            )
+        ]
+    )
+
+    with pytest.raises(ValueError, match="Plug id 'adobe' is already registered"):
+        plug_metadata_builder.build()

--- a/tests/runtime/test_models.py
+++ b/tests/runtime/test_models.py
@@ -91,3 +91,48 @@ def test_meta_config_supports_plugs(tmp_path):
             href="/static/main-menu.js",
         )
     ]
+
+
+def test_meta_config_supports_container_plugs(tmp_path):
+    metadata_path = tmp_path / "meta.yaml"
+    metadata_path.write_text(
+        yaml.safe_dump(
+            {
+                "openapi": "/bypass/openapi.json",
+                "version": "1.0.0",
+                "events": [],
+                "plugs": [
+                    {
+                        "id": "learn-extensions",
+                        "name": "Learn Extensions",
+                        "socket": "portal",
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = MetaConfig.from_file(metadata_path)
+
+    assert result.plugs == [
+        MetaPlug(id="learn-extensions", name="Learn Extensions", socket="portal")
+    ]
+
+
+def test_to_file_omits_container_plug_href(tmp_path):
+    metadata_path = tmp_path / "meta.yaml"
+    meta_config = MetaConfig(
+        openapi="/bypass/openapi.json",
+        version="1.0.0",
+        events=[],
+        plugs=[MetaPlug(id="learn-extensions", name="Learn Extensions", socket="portal")],
+    )
+
+    meta_config.to_file(metadata_path)  # act
+
+    written_payload = yaml.safe_load(metadata_path.read_text(encoding="utf-8"))
+    assert written_payload["plugs"] == [
+        {"id": "learn-extensions", "name": "Learn Extensions", "socket": "portal"}
+    ]

--- a/tests/test_extension_app.py
+++ b/tests/test_extension_app.py
@@ -15,6 +15,7 @@ from mpt_extension_sdk.routing import (
     EventDeliveryMode,
     EventRouteDefinition,
     EventRouter,
+    NavigationPlug,
     Plug,
     PlugRouter,
     RouteType,
@@ -199,8 +200,50 @@ def test_meta_config_rejects_invalid_plug(mocker):
     )
     app.include_router(plug_router)
 
-    with pytest.raises(TypeError, match="Plug providers must return Plug instances"):
+    with pytest.raises(TypeError, match="Plug providers must return Plug or NavigationPlug"):
         app.to_meta_config()
+
+
+def test_meta_config_includes_navigation_plug(mocker):
+    plug_router = PlugRouter()
+    app = ExtensionApp()
+    container = NavigationPlug(
+        id="learn-extensions",
+        name="Learn Extensions",
+        socket="portal",
+        description="Learning resources",
+        icon="learn.png",
+    )
+    plug_router.register()(
+        mocker.MagicMock(
+            return_value=[
+                container,
+                Plug(
+                    id="guide",
+                    name="Guide",
+                    description="Extension guide",
+                    socket=container.nested_socket,
+                    href="guide.js",
+                ),
+            ],
+            spec=Callable,
+            __name__="plug_provider",
+        )
+    )
+    app.include_router(plug_router)
+
+    result = app.to_meta_config()
+
+    assert result.plugs is not None
+    assert result.plugs[0].model_dump(exclude_none=True) == {
+        "id": "learn-extensions",
+        "name": "Learn Extensions",
+        "description": "Learning resources",
+        "icon": "/static/learn.png",
+        "socket": "portal",
+    }
+    assert result.plugs[1].socket == "portal.learn-extensions"
+    assert result.plugs[1].href == "/static/guide.js"
 
 
 def test_ext_app_rejects_api_event_path_collision(dummy_handler):


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Introduce `NavigationPlug`, a dedicated navigation-container plug type for nested navigation (MPT-22805, part of epic MPT-22802).

A navigation container is a pure grouping node: it ships no bundle, so it has no `href`, and its `id` derives a nested socket (`<socket>.<id>`, exposed as `nested_socket`) under which child plugs mount.

- `NavigationPlug` in `mpt_extension_sdk.routing.plugs`: `id`, `name`, `socket`, optional `description`/`icon`, no `href` field; strict per-type validation with clear errors (supplying `href` fails, blank fields fail); icon normalized under `/static/` like bundle plug assets.
- `PlugRouter` providers can return a mix of `Plug` and `NavigationPlug` (`PlugRouteCallback` widened; `PlugMetadataBuilder` validates both types and keeps ids unique across them).
- Manifest / registration serialization emits containers without an `href` key: `MetaPlug.href` and `MetaPlug.description` are now optional, and the registration payload uses `exclude_none=True` (aligning it with how `meta.yaml` is written — previously it sent `"href": null`-style keys).
- `mpt-ext meta validate` skips `href` asset checks for containers while still validating icons.
- `NavigationPlug` exported from `mpt_extension_sdk` and `mpt_extension_sdk.routing`.
- Docs: new "Nested navigation" section in `docs/sdk_usage/plugs.md` with a two-level example; `docs/usage.md` topic map updated.

Note for reviewers: the `exclude_none=True` change on the registration payload also drops previously-null keys (`icon`, `condition`) for existing bundle plugs and events. This matches how `meta.yaml` has always been serialized, so the platform already accepts absent keys, but it is a wire-format change.

## Testing

- New unit tests cover construction, nested-socket derivation, per-type validation, and serialization (routing, builders, models, CLI, and end-to-end extension-app coverage).
- Full local validation passed: `ruff format --check`, `ruff check`, `flake8`, `mypy`, `uv lock --check`, and `pytest` (370 passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Introduced `NavigationPlug` to model nested navigation container plugs: `href` is disallowed/omitted, child plugs mount to a derived `nested_socket` in the form `<socket>.<id>`, and `id`/`name`/`socket` are validated (plus `description`/whitespace rules and icon normalization).
- Updated routing, runtime metadata/model building, and registration/serialization to support both `Plug` and `NavigationPlug`; container plug serialization omits `href`, and unset optional fields are excluded from registration payloads.
- Preserved icon validation and normalization (icons normalized under the static path) and updated CLI validation to skip `href` checks for container plugs while still validating icons.
- Updated public exports and types to include `NavigationPlug`, and expanded accepted plug-provider return types (`Plug | NavigationPlug`).
- Added documentation for nested navigation containers and `Plug | NavigationPlug` usage with child plugs mounting via `nested_socket`.
- Added unit and end-to-end coverage for construction, validation, nested sockets, serialization, routing, builders/models, extension-app meta conversion, and CLI behavior; reported validation passes include formatting, linting, type checking, lock verification, and 370 tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->