### PR TITLE
MPT-23123 Update EventResponse serialized values from Defer to Delay

### DIFF
--- a/docs/sdk_usage/error-handling.md
+++ b/docs/sdk_usage/error-handling.md
@@ -105,6 +105,11 @@ For event and task routes, the SDK maps the final exception to an
 | `ExtRuntimeError` | `cancel(reason="Runtime error")` |
 | any other exception | `cancel(reason="Unexpected error")` |
 
+On the wire, the rescheduled response serializes as
+`{"response": "Delay", "delay": <seconds>}`, where `delay` is an integer number
+of seconds, and the canceled response as
+`{"response": "Cancel", "cancelReason": "<reason>"}`.
+
 Because `StopStepError` becomes `CancelError` and `DeferStepError` becomes
 `DeferError`, raising step errors is enough to drive the event outcome. You
 rarely need to construct `CancelError` or `DeferError` directly.

--- a/mpt_extension_sdk/api/models/events.py
+++ b/mpt_extension_sdk/api/models/events.py
@@ -11,7 +11,7 @@ class ResponseEnum(StrEnum):
     """Valid outcome values for event response."""
 
     CANCEL = "Cancel"
-    DEFER = "Defer"
+    DEFER = "Delay"
     OK = "OK"
 
 
@@ -67,7 +67,7 @@ class EventResponse(APIBaseModel):
         str | None, Field(serialization_alias="cancelReason", validation_alias="cancelReason")
     ] = None
     defer_delay: Annotated[
-        str | None, Field(serialization_alias="deferDelay", validation_alias="deferDelay")
+        int | None, Field(serialization_alias="delay", validation_alias="delay")
     ] = None
 
     @classmethod
@@ -97,4 +97,4 @@ class EventResponse(APIBaseModel):
         Returns:
             A Defer EventResponse.
         """
-        return cls(response=ResponseEnum.DEFER, defer_delay=f"PT{seconds}S")
+        return cls(response=ResponseEnum.DEFER, defer_delay=seconds)

--- a/tests/api/models/test_events.py
+++ b/tests/api/models/test_events.py
@@ -18,4 +18,10 @@ def test_event_response_reschedule():
     result = EventResponse.reschedule(seconds=0)
 
     assert result.response == ResponseEnum.DEFER
-    assert result.defer_delay == "PT0S"
+    assert result.defer_delay == 0
+
+
+def test_event_response_reschedule_to_dict():
+    result = EventResponse.reschedule(seconds=120)
+
+    assert result.to_dict() == {"response": "Delay", "delay": 120}


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

The MPT platform changed the `EventResponse` contract: the response value `Defer` is now `Delay`, and the `deferDelay` ISO 8601 duration field is now `delay`, an integer number of seconds. This PR updates only the serialized contract in the SDK:

- `ResponseEnum.DEFER` value changes from `"Defer"` to `"Delay"` (the enum member name stays `DEFER`).
- The `defer_delay` field serialization/validation alias changes from `"deferDelay"` to `"delay"`, and its type from ISO 8601 duration string (`"PT300S"`) to `int` seconds (the attribute name stays `defer_delay`).
- `docs/sdk_usage/error-handling.md` now documents the serialized shape of the rescheduled and canceled event responses.

The Python API surface (`ResponseEnum.DEFER`, `EventResponse.reschedule(seconds=...)`) is unchanged, so extensions already in production do not require code changes.

## Testing

- `make check-all`: ruff clean, 357 tests passed (includes a new test asserting the serialized contract).

## Jira

- [MPT-23123](https://softwareone.atlassian.net/browse/MPT-23123)


[MPT-23123]: https://softwareone.atlassian.net/browse/MPT-23123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updates `EventResponse` serialization to match the MPT contract.
- Serializes `ResponseEnum.DEFER` as `"Delay"` while preserving the `DEFER` member.
- Renames serialized `defer_delay` to `"delay"` and represents it as integer seconds.
- Preserves the Python API and adds coverage for the updated payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->