### PR TITLE
MPT-23237 Serve ops endpoints under /bypass prefix for Kubernetes probes

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,9 +62,12 @@ The SDK runtime has two main execution surfaces:
 persists the returned identity when present, and starts the exported ASGI app through Ziticorn.
 `runtime/app.py` assembles the FastAPI app, configures middleware and observability,
 loads the extension's exported `ext_app`, and mounts every registered route.
-It also registers built-in operational endpoints: `/health` (status plus extension
-version), `/live` (liveness probe), and `/ready` (readiness probe, returning `503`
-until application startup completes and after shutdown begins).
+It also registers built-in operational endpoints under the `/bypass` prefix:
+`/bypass/health` (status plus extension version), `/bypass/live` (liveness probe),
+and `/bypass/ready` (readiness probe, returning `503` until application startup
+completes and after shutdown begins). The `/bypass` prefix keeps these endpoints
+reachable by Kubernetes probes over plain HTTP, because Ziticorn serves `/bypass/*`
+directly instead of over the OpenZiti overlay.
 
 At the moment, `event` and `api` route families are implemented end-to-end in
 runtime request handling. Event routes are also emitted into `meta.yaml`. The

--- a/mock_app/docs/postman_collection.json
+++ b/mock_app/docs/postman_collection.json
@@ -80,9 +80,9 @@
         },
         "header": [],
         "url": {
-          "raw": "{{base_url}}/health",
+          "raw": "{{base_url}}/bypass/health",
           "host": ["{{base_url}}"],
-          "path": ["health"]
+          "path": ["bypass", "health"]
         }
       },
       "response": []
@@ -96,9 +96,9 @@
         },
         "header": [],
         "url": {
-          "raw": "{{base_url}}/live",
+          "raw": "{{base_url}}/bypass/live",
           "host": ["{{base_url}}"],
-          "path": ["live"]
+          "path": ["bypass", "live"]
         }
       },
       "response": []
@@ -112,9 +112,9 @@
         },
         "header": [],
         "url": {
-          "raw": "{{base_url}}/ready",
+          "raw": "{{base_url}}/bypass/ready",
           "host": ["{{base_url}}"],
-          "path": ["ready"]
+          "path": ["bypass", "ready"]
         }
       },
       "response": []

--- a/mpt_extension_sdk/runtime/app.py
+++ b/mpt_extension_sdk/runtime/app.py
@@ -161,15 +161,15 @@ def _configure_middlewares(app: FastAPI) -> None:
 def _register_builtin_routes(app: FastAPI) -> None:
     """Register built-in operational routes exposed by the runtime."""
 
-    @app.get("/health", tags=["ops"])
+    @app.get("/bypass/health", tags=["ops"])
     async def health() -> dict[str, str]:  # noqa: WPS430
         return {"status": "ok", "version": app.version}
 
-    @app.get("/live", tags=["ops"])
+    @app.get("/bypass/live", tags=["ops"])
     async def live() -> dict[str, str]:  # noqa: WPS430
         return {"status": "ok"}
 
-    @app.get("/ready", tags=["ops"])
+    @app.get("/bypass/ready", tags=["ops"])
     async def ready() -> JSONResponse:  # noqa: WPS430
         if app.state.ready:
             return JSONResponse({"status": "ok"})

--- a/tests/runtime/test_app.py
+++ b/tests/runtime/test_app.py
@@ -142,7 +142,7 @@ def test_create_runtime_app_registers_health(runtime_settings, runtime_app_patch
 
     result = runtime_app.create_runtime_app(runtime_settings)
 
-    response = TestClient(result).get("/health")
+    response = TestClient(result).get("/bypass/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok", "version": extension_app.version}
 
@@ -150,7 +150,7 @@ def test_create_runtime_app_registers_health(runtime_settings, runtime_app_patch
 def test_create_runtime_app_registers_live(runtime_settings, runtime_app_patches):
     result = runtime_app.create_runtime_app(runtime_settings)
 
-    response = TestClient(result).get("/live")
+    response = TestClient(result).get("/bypass/live")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
 
@@ -158,7 +158,7 @@ def test_create_runtime_app_registers_live(runtime_settings, runtime_app_patches
 def test_ready_returns_unavailable_before_startup(runtime_settings, runtime_app_patches):
     result = runtime_app.create_runtime_app(runtime_settings)
 
-    response = TestClient(result).get("/ready")
+    response = TestClient(result).get("/bypass/ready")
     assert response.status_code == 503
     assert response.json() == {"status": "unavailable"}
 
@@ -180,8 +180,8 @@ def test_ready_follows_app_lifespan(runtime_settings, runtime_app_patches):
     result = runtime_app.create_runtime_app(runtime_settings)
 
     with TestClient(result) as client:
-        started_response = client.get("/ready")
-    stopped_response = TestClient(result).get("/ready")
+        started_response = client.get("/bypass/ready")
+    stopped_response = TestClient(result).get("/bypass/ready")
     assert started_response.status_code == 200
     assert started_response.json() == {"status": "ok"}
     assert stopped_response.status_code == 503


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What

Move the built-in operational endpoints from `/health`, `/live` and `/ready` to `/bypass/health`, `/bypass/live` and `/bypass/ready`. The old paths are removed.

## Why

In production the whole FastAPI app — including these ops routes — is served only through Ziticorn over the OpenZiti overlay, so it requires a valid Ziti identity. Kubernetes liveness/readiness/startup probes hit the pod over plain HTTP without such an identity and therefore could not reach the endpoints. Ziticorn serves the `/bypass/*` prefix directly (bypassing the overlay), so under the new paths the probes can succeed unauthenticated while application traffic continues to flow over OpenZiti.

Fixes [MPT-23237](https://softwareone.atlassian.net/browse/MPT-23237).

## Changes

- `mpt_extension_sdk/runtime/app.py` — `_register_builtin_routes()` now registers `/bypass/health`, `/bypass/live`, `/bypass/ready`.
- `tests/runtime/test_app.py` — tests updated to the new paths.
- `docs/architecture.md` — documents the ops endpoints under `/bypass` and why the prefix is used.
- `mock_app/docs/postman_collection.json` — ops requests updated to the new paths.

## Testing

- `make check` — ruff format + ruff + flake8 + mypy + `uv lock --check` all pass.
- `make check-all` — full suite: **373 passed**, coverage 98%.


[MPT-23237]: https://softwareone.atlassian.net/browse/MPT-23237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Moved built-in health, liveness, and readiness endpoints to `/bypass/health`, `/bypass/live`, and `/bypass/ready` for unauthenticated Kubernetes probes.
- Updated runtime tests, architecture documentation, and the mock app Postman collection.
- Preserved readiness behavior and verified 373 tests with 98% coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->