### PR TITLE
MPT-23319 Enable OTLP exporter only when an OTLP endpoint is configured

### DIFF
--- a/.env.demo
+++ b/.env.demo
@@ -8,8 +8,7 @@ SDK_EXTENSION_ID=EXT-2345-3554
 SDK_EXTENSION_URL=http://wiremock:8080/extension
 SDK_OTEL_SERVICE_NAME=Swo.Extension.Demo
 SDK_OBSERVABILITY_ENABLED=true
-# OTLP exporter example for the local Jaeger setup in compose.demo.yaml.
-SDK_OTEL_EXPORTERS=otlp
+# Setting the OTLP endpoint enables the OTLP exporter (local Jaeger from compose.demo.yaml).
 OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4318
 OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
 # Migrations

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,8 +24,12 @@ The SDK runtime relies on these settings:
 | `SDK_OBSERVABILITY_ENABLED` | `true` | `false` | Enables SDK observability bootstrap |
 | `SDK_APPLICATIONINSIGHTS_CONNECTION_STRING` | - | `InstrumentationKey=...` | Azure Monitor connection string used by the SDK observability bootstrap |
 | `SDK_OTEL_SERVICE_NAME` | - | `my-extension` | Optional OpenTelemetry service name override |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | exporter default | `http://jaeger:4318` | OTLP collector endpoint used when OTLP export is enabled |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | - | `http://jaeger:4318` | OTLP collector endpoint; setting it enables the OTLP exporter |
 | `OTEL_EXPORTER_OTLP_PROTOCOL` | exporter default | `http/protobuf` | OTLP protocol for the configured exporter |
+
+The standard traces-specific variable `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+can be used instead; when set, it also enables the OTLP exporter and takes
+precedence over `OTEL_EXPORTER_OTLP_ENDPOINT`.
 
 The demo environment files may also include integration-specific variables such
 as `MPT_PORTAL_BASE_URL`. Those are example application settings for the
@@ -95,12 +99,14 @@ When observability is enabled, the SDK bootstraps:
 - FastAPI instrumentation
 - HTTPX client instrumentation
 - logging correlation through OpenTelemetry logging instrumentation
-- OTLP exporting by default
+- OTLP exporting when `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or
+  `OTEL_EXPORTER_OTLP_ENDPOINT` is set
 - Azure Monitor exporting when `SDK_APPLICATIONINSIGHTS_CONNECTION_STRING` is set
 
-OpenTelemetry exporter-specific variables such as
-`OTEL_EXPORTER_OTLP_ENDPOINT` are read by the underlying OpenTelemetry
-exporter, not by `RuntimeSettings` directly.
+The SDK reads the OTLP endpoint variables only to decide whether the OTLP
+exporter is enabled. Their values, together with other exporter-specific
+variables such as `OTEL_EXPORTER_OTLP_PROTOCOL`, are consumed by the
+underlying OpenTelemetry exporter, not by `RuntimeSettings` directly.
 
 Document additional repository-specific configuration here when SDK runtime
 requirements expand.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -14,6 +14,18 @@ The `migrations` topic here covers SDK compatibility changes that require consum
 
 ## Current Migration Notes
 
+### OTLP exporter is no longer enabled unconditionally
+
+The observability bootstrap used to register the OTLP span exporter whenever
+`SDK_OBSERVABILITY_ENABLED` was `true`, even without a reachable collector.
+The OTLP exporter is now enabled only when `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+or `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+
+Consumer action: deployments that relied on the implicit default OTLP endpoint
+(`http://localhost:4318`) without declaring the endpoint variable must now set
+`OTEL_EXPORTER_OTLP_ENDPOINT` explicitly. Setups that already declare the
+endpoint (for example a local Jaeger collector) keep working unchanged.
+
 
 Add a section here only when this repository introduces a consumer-facing
 compatibility change that requires upgrade guidance.

--- a/docs/sdk_usage/observability.md
+++ b/docs/sdk_usage/observability.md
@@ -35,10 +35,15 @@ Observability is controlled through runtime environment variables (see
 - `SDK_OTEL_SERVICE_NAME` overrides the reported service name.
 - `SDK_APPLICATIONINSIGHTS_CONNECTION_STRING` enables the Azure Monitor exporter
   when set.
+- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_ENDPOINT` enables
+  the OTLP exporter when set.
 
-The SDK always configures the OTLP exporter. When the Application Insights
-connection string is set, it additionally configures the Azure Monitor
-exporter. That exporter requires the optional dependency:
+Each exporter is activated only when its destination configuration is present:
+the OTLP exporter when an OTLP endpoint variable is set, and the Azure Monitor
+exporter when the Application Insights connection string is set. When neither
+is configured, the tracer provider runs without exporters, so instrumentation
+stays active without export noise. The Azure Monitor exporter requires the
+optional dependency:
 
 ```bash
 pip install "mpt-extension-sdk[azure-monitor]"

--- a/mpt_extension_sdk/observability/config.py
+++ b/mpt_extension_sdk/observability/config.py
@@ -16,7 +16,9 @@ class ObservabilityConfig:
     @classmethod
     def from_runtime_settings(cls, runtime_settings: RuntimeSettings) -> Self:
         """Build observability settings from the runtime configuration."""
-        configured_exporters = ["otlp"]
+        configured_exporters = []
+        if runtime_settings.otel_otlp_endpoint:
+            configured_exporters.append("otlp")
         if runtime_settings.applicationinsights_connection_string:
             configured_exporters.append("azure_monitor")
 

--- a/mpt_extension_sdk/settings/runtime.py
+++ b/mpt_extension_sdk/settings/runtime.py
@@ -36,6 +36,7 @@ class RuntimeSettings(BaseSettings):
     observability_enabled: bool
     applicationinsights_connection_string: str
     otel_service_name: str
+    otel_otlp_endpoint: str
     ziti_workers: int
     ziti_reload: bool
 
@@ -76,6 +77,10 @@ class RuntimeSettings(BaseSettings):
                 "SDK_APPLICATIONINSIGHTS_CONNECTION_STRING", ""
             ),
             otel_service_name=os.getenv("SDK_OTEL_SERVICE_NAME", ""),
+            otel_otlp_endpoint=(
+                os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+                or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
+            ),
             local_host=os.getenv("SDK_LOCAL_HOST", "0.0.0.0"),  # noqa: S104
             local_port=cls.int_env("SDK_LOCAL_PORT", default=DEFAULT_LOCAL_PORT),
             local_reload=cls.bool_env("SDK_LOCAL_RELOAD", default=True),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,6 +137,7 @@ def runtime_settings(meta_config):
         observability_enabled=False,
         applicationinsights_connection_string="",
         otel_service_name="tests",
+        otel_otlp_endpoint="",
         ziti_workers=4,
         ziti_reload=False,
     )

--- a/tests/observability/test_bootstrap.py
+++ b/tests/observability/test_bootstrap.py
@@ -1,3 +1,4 @@
+import dataclasses
 from collections.abc import Callable
 
 import pytest
@@ -79,6 +80,43 @@ def test_observability_config_uses_service_name(runtime_settings):
     result = ObservabilityConfig.from_runtime_settings(runtime_settings)
 
     assert result.service_name == runtime_settings.otel_service_name
+
+
+def test_config_without_exporter_destinations(runtime_settings):
+    result = ObservabilityConfig.from_runtime_settings(runtime_settings)
+
+    assert result.exporters == ()
+
+
+def test_config_enables_otlp_when_endpoint_set(runtime_settings):
+    settings = dataclasses.replace(runtime_settings, otel_otlp_endpoint="http://jaeger:4318")
+
+    result = ObservabilityConfig.from_runtime_settings(settings)
+
+    assert result.exporters == ("otlp",)
+
+
+def test_config_enables_azure_when_conn_str_set(runtime_settings):
+    settings = dataclasses.replace(
+        runtime_settings,
+        applicationinsights_connection_string="InstrumentationKey=test",
+    )
+
+    result = ObservabilityConfig.from_runtime_settings(settings)
+
+    assert result.exporters == ("azure_monitor",)
+
+
+def test_config_combines_configured_exporters(runtime_settings):
+    settings = dataclasses.replace(
+        runtime_settings,
+        otel_otlp_endpoint="http://jaeger:4318",
+        applicationinsights_connection_string="InstrumentationKey=test",
+    )
+
+    result = ObservabilityConfig.from_runtime_settings(settings)
+
+    assert result.exporters == ("otlp", "azure_monitor")
 
 
 def test_bootstrap_skips_disabled(mocker):

--- a/tests/settings/test_runtime.py
+++ b/tests/settings/test_runtime.py
@@ -106,6 +106,7 @@ def test_load_reads_runtime_env(
         result.observability_enabled,
         result.applicationinsights_connection_string,
         result.otel_service_name,
+        result.otel_otlp_endpoint,
         result.local_host,
         result.local_port,
         result.local_reload,
@@ -116,6 +117,7 @@ def test_load_reads_runtime_env(
         Path.cwd() / "meta.yaml",
         "INFO",
         True,
+        "",
         "",
         "",
         "0.0.0.0",
@@ -139,6 +141,7 @@ def test_load_uses_explicit_runtime_overrides(
             "SDK_OBSERVABILITY_ENABLED": "false",
             "SDK_APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=test",
             "SDK_OTEL_SERVICE_NAME": "svc",
+            "OTEL_EXPORTER_OTLP_ENDPOINT": "http://jaeger:4318",
             "SDK_LOCAL_HOST": "127.0.0.1",
             "SDK_LOCAL_PORT": "9000",
             "SDK_LOCAL_RELOAD": "false",
@@ -162,6 +165,7 @@ def test_load_uses_explicit_runtime_overrides(
         result.observability_enabled,
         result.applicationinsights_connection_string,
         result.otel_service_name,
+        result.otel_otlp_endpoint,
         result.local_host,
         result.local_port,
         result.local_reload,
@@ -175,6 +179,7 @@ def test_load_uses_explicit_runtime_overrides(
         False,
         "InstrumentationKey=test",
         "svc",
+        "http://jaeger:4318",
         "127.0.0.1",
         9000,
         False,
@@ -182,6 +187,27 @@ def test_load_uses_explicit_runtime_overrides(
         8,
         True,
     )
+
+
+def test_load_prefers_traces_otlp_endpoint(
+    mocker, runtime_env, settings_loader_state, fake_package, meta_config
+):
+    mocker.patch.dict(
+        "os.environ",
+        {
+            "OTEL_EXPORTER_OTLP_ENDPOINT": "http://generic:4318",
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": "http://traces:4318",
+        },
+    )
+    mocker.patch(
+        "mpt_extension_sdk.settings.runtime.import_module",
+        autospec=True,
+        return_value=mocker.Mock(ext_app=FakeExtensionApp(meta_config)),
+    )
+
+    result = RuntimeSettings.load()
+
+    assert result.otel_otlp_endpoint == "http://traces:4318"
 
 
 def test_load_uses_uuid_when_hostname_blank(


### PR DESCRIPTION
🤖 AI-generated PR — Please review carefully.

## What was done

Fixes [MPT-23319](https://softwareone.atlassian.net/browse/MPT-23319).

The observability bootstrap registered the OTLP span exporter unconditionally whenever `SDK_OBSERVABILITY_ENABLED` was `true`. Deployments exporting only to Azure Monitor had no way to turn OTLP off, so the `BatchSpanProcessor` kept retrying against the default `http://localhost:4318` endpoint and flooded the logs with connection errors.

The fix applies the rule already used for Azure Monitor to every exporter: **an exporter is enabled only when its destination configuration is present.**

- `SDK_APPLICATIONINSIGHTS_CONNECTION_STRING` set → `azure_monitor` exporter (unchanged)
- `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_ENDPOINT` set → `otlp` exporter
- Neither set → tracer provider without exporters (instrumentation stays active, no export noise)

The SDK reads the OTLP endpoint variables only as a presence signal; their values keep being consumed by the underlying `OTLPSpanExporter` as standard OpenTelemetry configuration.

### Changes

- `mpt_extension_sdk/settings/runtime.py`: new `otel_otlp_endpoint` runtime setting resolved from `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` (preferred) or `OTEL_EXPORTER_OTLP_ENDPOINT`.
- `mpt_extension_sdk/observability/config.py`: exporter list starts empty and adds `otlp`/`azure_monitor` conditionally.
- `.env.demo`: drop the never-implemented `SDK_OTEL_EXPORTERS` variable (the OTLP endpoint already enables the exporter).
- Docs: `configuration.md`, `sdk_usage/observability.md`, and a migration note in `migrations.md`.
- Tests: exporter selection coverage in `tests/observability/test_bootstrap.py` and runtime settings coverage in `tests/settings/test_runtime.py`.

### Behavior change

Deployments that relied on the implicit default OTLP endpoint (`http://localhost:4318`) without declaring the endpoint variable must now set `OTEL_EXPORTER_OTLP_ENDPOINT` explicitly. Local Jaeger setups that already declare it keep working unchanged.

## Testing

- `make check`: ruff, flake8, mypy, uv lock — all green.
- `make test`: 378 passed, `settings/runtime.py` at 100% coverage.


[MPT-23319]: https://softwareone.atlassian.net/browse/MPT-23319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Closes [MPT-23319](https://softwareone.atlassian.net/browse/MPT-23319)

- Enable OTLP tracing export only when an OTLP endpoint is configured (prevents implicit retries to `http://localhost:4318`).
- Add `otel_otlp_endpoint`, resolved from `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` (preferred) or `OTEL_EXPORTER_OTLP_ENDPOINT`.
- Register `azure_monitor` only when `SDK_APPLICATIONINSIGHTS_CONNECTION_STRING` is configured.
- Create the tracer provider without exporters when neither OTLP nor Azure Monitor is configured (keeps instrumentation active without export noise).
- Remove the unused `SDK_OTEL_EXPORTERS` entry from `.env.demo`.
- Update documentation and migration notes to reflect the new conditional OTLP activation and endpoint precedence.
- Extend tests to validate exporter selection logic and endpoint precedence; updated fixtures and runtime settings accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->